### PR TITLE
Rename Improver

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.14'
+          node-version: '16.14.2'
           cache: 'yarn'
       - name: Find PR number 
         uses: jwalton/gh-find-current-pr@v1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.13.2'
+          node-version: '16.14'
           cache: 'yarn'
       - name: Find PR number 
         uses: jwalton/gh-find-current-pr@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.0] - 2023-04-17
+### Updated
+- Optimized logic to checkForRename using package string-similarity
+- Optimized logic to traverse over a repo using "glob" instead of "walk"
+- Improved logic of ignoring a path from .syncignore
+
 ## [3.18.0] - 2023-03-29
 ### Fixed
 - Waiting before retrying socket connection if error occurs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.19.0] - 2023-04-17
-### Updated
-- Optimized logic to checkForRename using package string-similarity
-- Optimized logic to traverse over a repo using "glob" instead of "walk"
+- Optimized logic to checkForRename using [string-similarity](https://www.npmjs.com/package/string-similarity)
+    - Earlier logic was taking ~15s for comparing text of files of ~50KB. With "string-similarity" it is in miliseconds
+- Fixed a bug in getting `PotentialMatchingFiles` for rename
+    - Earlier it was checking against every file of the repo. Now it considers only those files from shadow repo that possess following properties:
+        - Shadow file should not be ignorable from .syncignore
+        - Actual file is not present for the shadow file
+        - Relative path of shadow file should be present in config file
+        - Shadow file should not be a binary file since we are going to match the text of files
+        - Shadow file should not be empty
+    - Also getting `PotentialMatchingFiles` only once per repo instead of once per file
 - Improved logic of ignoring a path from .syncignore
+    - Using common function everywhere for "[ignores](https://www.npmjs.com/package/ignore)" which ignores path depending on content of .syncignore
+    - Improved logic to ignore DEFAULT-SKIP-DIRECTORIES wherever they are present in the project e.g. `node_modules` etc
 
 ## [3.18.0] - 2023-03-29
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "CodeSync",
   "description": "Stream code to the cloud. Save it forever. Play it back later. No commits needed.",
   "icon": "images/icon.png",
-  "version": "3.17.3",
+  "version": "3.18.0",
   "publisher": "codesync",
   "engines": {
     "vscode": "^1.32.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "engines": {
     "vscode": "^1.32.0",
     "npm": "8.1.2",
-    "node": "16.13.2"
+    "node": "16.14.2"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
       },
       {
         "view": "codesync-signed-up-is-sub-dir-syncignored",
-        "contents": "Current directory is syncignored by a parent repo. To sync this directory, remove it from .syncignore.\n[Open .syncignore](command:codesync.openSyncIgnore)\n[View parent repo on web](command:codesync.trackRepo)\n[Disconnect parent repo](command:codesync.disconnectRepo))\n[View Dashboard](command:codesync.viewDashboard)\n[Logout](command:codesync.logout)"
+        "contents": "Current directory is syncignored by a parent repo. To sync this directory, remove it from .syncignore.\n[Open .syncignore](command:codesync.openSyncIgnore)\n[View parent repo on web](command:codesync.trackRepo)\n[Disconnect parent repo](command:codesync.disconnectRepo)\n[View Dashboard](command:codesync.viewDashboard)\n[Logout](command:codesync.logout)"
       },
       {
         "view": "codesync-is-loading",
@@ -283,8 +283,8 @@
     "@types/node-fetch": "^2.5.12",
     "@types/proper-lockfile": "^4.1.2",
     "@types/run-parallel": "^1.1.0",
+    "@types/string-similarity": "^4.0.0",
     "@types/untildify": "^4.0.0",
-    "@types/walk": "^2.3.0",
     "aws-sdk": "^2.1286.0",
     "current-git-branch": "^1.1.0",
     "dateformat": "^4.4.1",
@@ -293,6 +293,7 @@
     "esbuild": "^0.16.12",
     "express": "^4.18.2",
     "form-data": "^4.0.0",
+    "glob": "^10.0.0",
     "ignore": "^5.2.0",
     "isbinaryfile": "^5.0.0",
     "jest-fetch-mock": "^3.0.3",
@@ -301,8 +302,8 @@
     "node-fetch": "^3.3.0",
     "proper-lockfile": "^4.1.2",
     "run-parallel": "^1.2.0",
+    "string-similarity": "^4.0.4",
     "untildify": "^4.0.0",
-    "walk": "^2.3.14",
     "websocket": "^1.0.34"
   },
   "repository": {

--- a/src/codesyncd/populate_buffer.ts
+++ b/src/codesyncd/populate_buffer.ts
@@ -176,6 +176,7 @@ class PopulateBuffer {
         /*
         If a file is renamed in actual repo, it will be present in the shadow repo with pervious name.
         So potential renamed files in the shadow repo should possess following properties
+        - Shadow file should not be ignorable from .syncignore
         - Actual file should not be present for the shadow file
         - Relative path of shadow file should be present in config file
         - Shadow file should not be a binary file since we are going to match the text of files

--- a/src/codesyncd/utils.ts
+++ b/src/codesyncd/utils.ts
@@ -18,7 +18,7 @@ import { uploadFileToServer } from '../utils/upload_utils';
 import { CodeSyncLogger } from '../logger';
 import { generateSettings } from "../settings";
 import { pathUtils } from "../utils/path_utils";
-import { checkSubDir, getActiveUsers, isRepoActive, readYML } from '../utils/common';
+import { checkSubDir, getActiveUsers, isRepoActive, readFile, readYML } from '../utils/common';
 import { getPlanLimitReached } from '../utils/pricing_utils';
 import { CodeSyncState, CODESYNC_STATES } from '../utils/state_utils';
 
@@ -131,7 +131,7 @@ export const getDIffForDeletedFile = (repoPath: string, branch: string, relPath:
 		cleanUpDeleteDiff(repoPath, branch, relPath, configJSON);
 		return diff;
 	}
-	const shadowText = fs.readFileSync(shadowPath, "utf8");
+	const shadowText = readFile(shadowPath);
 	const dmp = new diff_match_patch();
 	const patches = dmp.patch_make(shadowText, "");
 	diff = dmp.patch_toText(patches);
@@ -139,46 +139,6 @@ export const getDIffForDeletedFile = (repoPath: string, branch: string, relPath:
 	return diff;
 };
 
-export const similarity = (s1: string, s2: string) => {
-	let longer = s1;
-	let shorter = s2;
-	if (s1.length < s2.length) {
-		longer = s2;
-		shorter = s1;
-	}
-	const longerLength = longer.length;
-	if (longerLength == 0) {
-		return 1.0;
-	}
-	return (longerLength - editDistance(longer, shorter)) / longerLength;
-};
-
-const editDistance = (s1: string, s2: string) => {
-	s1 = s1.toLowerCase();
-	s2 = s2.toLowerCase();
-
-	const costs: number[] = [];
-	for (let i = 0; i <= s1.length; i++) {
-		let lastValue = i;
-		for (let j = 0; j <= s2.length; j++) {
-			if (i == 0)
-				costs[j] = j;
-			else {
-				if (j > 0) {
-					let newValue = costs[j - 1];
-					if (s1.charAt(i - 1) != s2.charAt(j - 1))
-						newValue = Math.min(Math.min(newValue, lastValue),
-							costs[j]) + 1;
-					costs[j - 1] = lastValue;
-					lastValue = newValue;
-				}
-			}
-		}
-		if (i > 0)
-			costs[s2.length] = lastValue;
-	}
-	return costs[s2.length];
-};
 
 export class statusBarMsgs {
 	/*

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,8 @@ export const IGNORABLE_DIRECTORIES = [
 	"node_modules",
 	".DS_Store",
 	".idea",
+	"coverage",
+	"bower_components"
 ];
 
 export const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
-import walk from "walk";
 import yaml from "js-yaml";
 import vscode from 'vscode';
+import { globSync } from 'glob';
 
 import { IDiff } from "../interface";
 import { initUtils } from "../init/utils";
-import { formatDatetime, getBranch, readYML } from "../utils/common";
+import { formatDatetime, getBranch, readFile, readYML } from "../utils/common";
 import { generateSettings } from "../settings";
 import { pathUtils } from "../utils/path_utils";
 import { diff_match_patch } from 'diff-match-patch';
@@ -124,7 +124,7 @@ export class eventHandler {
 				this.createdAt = formatDatetime(lstatShadow.mtimeMs);
 			}
 			// Read shadow file
-			shadowText = fs.readFileSync(shadowPath, "utf8");
+			shadowText = readFile(shadowPath);
 		}
 		// If shadow text is same as current content, no need to compute diffs
 		if (shadowText === currentText) return;
@@ -250,23 +250,17 @@ export class eventHandler {
 		const repoPath = this.repoPath;
 		const branch = this.branch;
 		this.isDelete = true;
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
-		const that = this;
-		// No need to skip repos here as it is for specific repo
-		const walker = walk.walk(shadowDirPath);
-		walker.on("file", function (root, fileStats, next) {
-			const filePath = path.join(root, fileStats.name);
-			const relPath = filePath.split(path.join(pathUtilsObj.formattedRepoPath, branch, path.sep))[1];
+		// No need to skip repos here as it is for specific directory
+		const shadowFiles = globSync(`${shadowDirPath}/**`, { nodir: true, dot: true });
+		shadowFiles.forEach(shadowFilePath => {
+			const relPath = shadowFilePath.split(path.join(pathUtilsObj.formattedRepoPath, branch, path.sep))[1];
 			const cacheRepoBranchPath = pathUtilsObj.getDeletedRepoBranchPath();
 			const cacheFilePath = path.join(cacheRepoBranchPath, relPath);
-			if (fs.existsSync(cacheFilePath)) {
-				return next();
-			}
+			if (fs.existsSync(cacheFilePath)) return;
 			// Create directories
 			const initUtilsObj = new initUtils(repoPath);
-			initUtilsObj.copyFilesTo([filePath], pathUtilsObj.getDeletedRepoPath(), true);
-			that.addDiff(relPath, "");
-			next();
+			initUtilsObj.copyFilesTo([shadowFilePath], pathUtilsObj.getDeletedRepoPath(), true);
+			this.addDiff(relPath, "");
 		});
 	};
 
@@ -334,29 +328,26 @@ export class eventHandler {
 		// No need to skip repos here as it is for specific repo
 		this.isRename = true;
 		const repoPath = this.repoPath;
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
-		const that = this;
-		const walker = walk.walk(newPath);
-		walker.on("file", function (root, fileStats, next) {
-			const newFilePath = path.join(root, fileStats.name);
-			const oldFilePath = newFilePath.replace(newPath, oldPath);
+		// No need to skip repos here as it is for specific directory
+		const renamedFiles = globSync(`${newPath}/**`, { nodir: true, dot: true });
+		renamedFiles.forEach(renamedFilePath => {
+			const oldFilePath = renamedFilePath.replace(newPath, oldPath);
 			const oldRelPath = oldFilePath.split(path.join(repoPath, path.sep))[1];
-			const newRelPath = newFilePath.split(path.join(repoPath, path.sep))[1];
+			const newRelPath = renamedFilePath.split(path.join(repoPath, path.sep))[1];
 			const diff = JSON.stringify({
 				'old_rel_path': oldRelPath,
 				'new_rel_path': newRelPath
 			});
 			// // Rename shadow file
-			const oldShadowPath = path.join(that.shadowRepoBranchPath, oldRelPath);
-			const newShadowPath = path.join(that.shadowRepoBranchPath, newRelPath);
+			const oldShadowPath = path.join(this.shadowRepoBranchPath, oldRelPath);
+			const newShadowPath = path.join(this.shadowRepoBranchPath, newRelPath);
 			if (fs.existsSync(oldShadowPath)) {
 				const initUtilsObj = new initUtils(repoPath);
 				initUtilsObj.copyForRename(oldShadowPath, newShadowPath);
 				fs.unlinkSync(oldShadowPath);
 			}
-			that.addPathToConfig(newRelPath, oldRelPath);
-			that.addDiff(newRelPath, diff);
-			next();
+			this.addPathToConfig(newRelPath, oldRelPath);
+			this.addDiff(newRelPath, diff);
 		});
 	};
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -27,9 +27,9 @@ export interface IFileToUpload {
 	file_path: string,
 	rel_path: string,
 	is_binary: boolean,
-	size: number,
-	created_at: number,
-	modified_at: number
+	size: number|undefined,
+	created_at: number|undefined,
+	modified_at: number|undefined
 }
 
 export interface IUser {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from "path";
 import yaml from 'js-yaml';
+import ignore from 'ignore';
 import dateFormat from "dateformat";
 import getBranchName from "current-git-branch";
 
@@ -81,26 +82,40 @@ export const checkSubDir = (currentRepoPath: string) => {
 export const getSyncIgnoreItems = (repoPath: string) => {
 	const syncIgnorePath = path.join(repoPath, SYNCIGNORE);
 	const syncIgnoreExists = fs.existsSync(syncIgnorePath);
-	if (!syncIgnoreExists) {
-		return [];
-	}
-	let syncIgnoreData = "";
-	syncIgnoreData = readFile(syncIgnorePath);
+	if (!syncIgnoreExists) return [];
+	const syncIgnoreData = readFile(syncIgnorePath);
 	const syncIgnoreItems = syncIgnoreData.split("\n");
-	return syncIgnoreItems.filter(item =>  item);
+	return syncIgnoreItems.filter(item => item && !item.startsWith("!"));
 };
 
-export const getSkipRepos = (repoPath: string, syncignoreItems: string[]) => {
-	const skipRepos = [...IGNORABLE_DIRECTORIES];
+export const getSkipPaths = (repoPath: string, syncignoreItems: string[]) => {
+	/*
+	Output of this is used by globSync to ignore given directories
+	That's why appending /**  at the end of each directory path
+	*/
+	const skipPaths = [...IGNORABLE_DIRECTORIES.map(ignoreDir => `${repoPath}/**/${ignoreDir}/**`)];
 	syncignoreItems.forEach((pattern) => {
-		const itemPath = path.join(repoPath, pattern);
-		if (!fs.existsSync(itemPath)) { return; }
-		const lstat = fs.lstatSync(itemPath);
-		if (lstat.isDirectory()) {
-			skipRepos.push(pattern);
+		for (const terminator of ["/", "/*", "/**"]) {
+			if (pattern.endsWith(terminator)) {
+				const splitPath = pattern.split(terminator);
+				pattern = splitPath.slice(0, splitPath.length-1).join("");
+				break;				
+			}
 		}
+		const itemPath = path.join(repoPath, pattern);
+		// Only need to append /** for directories
+		if (!fs.existsSync(itemPath) || !fs.lstatSync(itemPath).isDirectory()) return;
+		const _pattern = `${repoPath}/${pattern}/**`;
+		// Make sure there are no duplicates
+		if (skipPaths.includes(_pattern )) return;
+		skipPaths.push(_pattern );
 	});
-	return skipRepos;
+	return skipPaths;
+};
+
+export const isIgnoreAblePath = (relPath: string, paths: string[]) => {
+	const ig = ignore().add(paths);
+	return ig.ignores(relPath);
 };
 
 export const isEmpty = (obj: any) => {

--- a/src/utils/upload_utils.ts
+++ b/src/utils/upload_utils.ts
@@ -4,7 +4,7 @@ import fetch from "node-fetch";
 import { isBinaryFileSync } from "isbinaryfile";
 import { API_ROUTES } from "../constants";
 import { getPlanLimitReached, resetPlanLimitReached, setPlanLimitReached } from './pricing_utils';
-import { formatDatetime } from './common';
+import { formatDatetime, readFile } from './common';
 
 
 export const uploadRepoToServer = async (token: string, data: any) => {
@@ -139,7 +139,7 @@ export const uploadFileTos3 = async (filePath: string, presignedUrl: any) => {
 		// reject raises an expcetion so not using it
 		let content;
 		try {
-			content = fs.readFileSync(filePath, "utf8");
+			content = readFile(filePath);
 		} catch (e) {
 			resolve({error: `Could not read file: ${filePath}`});
 		}

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import yaml from "js-yaml";
 
-import {readYML} from "../../src/utils/common";
+import {readYML, readFile} from "../../src/utils/common";
 import {diff_match_patch} from "diff-match-patch";
 import {pathUtils} from "../../src/utils/path_utils";
 import {DEFAULT_BRANCH, VSCODE} from "../../src/constants";
@@ -58,6 +58,19 @@ export async function waitFor(seconds) {
     return await new Promise((r) => setTimeout(r, seconds*1000));
 }
 
+export function writeTestRepoFiles(repoPath) {
+    fs.mkdirSync(`${repoPath}/directory`);
+    Object.keys(TEST_REPO_RESPONSE).forEach(key => {
+        if (key === "urls") {
+            Object.keys(TEST_REPO_RESPONSE[key]).forEach(fileName => {
+                const repoFilePath = path.join(repoPath, fileName);
+                if (fs.existsSync(repoFilePath)) return;
+                fs.writeFileSync(repoFilePath, DUMMY_FILE_CONTENT);
+            });
+        }
+    });
+}
+
 export const PRE_SIGNED_URL = {
     'url': 'https://codesync.s3.amazonaws.com/',
     'fields': {
@@ -71,7 +84,7 @@ export const PRE_SIGNED_URL = {
 export const TEST_EMAIL = 'test@codesync.com';
 export const ANOTHER_TEST_EMAIL = 'anotherTest@codesync.com';
 export const INVALID_TOKEN_JSON = {"error": {"message": "Invalid token"}};
-export const SYNC_IGNORE_DATA = ".DS_Store\n.git\n\n\n.node_modules\n";
+export const SYNC_IGNORE_DATA = ".DS_Store\n.git\n\n\n.node_modules\n!tests";
 export const DUMMY_FILE_CONTENT = "DUMMY FILE CONTENT";
 
 export const TEST_USER = {
@@ -136,7 +149,7 @@ export const assertChangeEvent = (repoPath, diffsRepo, oldText, updatedText,
                                   fileRelPath, shadowFilePath,
                                   diffsCount = 1) => {
     // Read shadow file
-    const shadowText = fs.readFileSync(shadowFilePath, "utf8");
+    const shadowText = readFile(shadowFilePath);
     expect(shadowText).toStrictEqual(updatedText);
     // Verify correct diff file has been generated
     const diffFiles = fs.readdirSync(diffsRepo);

--- a/tests/test_codesyncd/utils.test.js
+++ b/tests/test_codesyncd/utils.test.js
@@ -10,8 +10,7 @@ import {
     cleanUpDeleteDiff,
     getDIffForDeletedFile,
     handleNewFileUpload,
-    isValidDiff,
-    similarity
+    isValidDiff
 } from "../../src/codesyncd/utils";
 import { createSystemDirectories } from "../../src/utils/setup_utils";
 import {
@@ -86,30 +85,6 @@ describe("isValidDiff",  () => {
         diffData.diff = "THIS IS DIFF";
         const isValid = isValidDiff(diffData);
         expect(isValid).toBe(true);
-    });
-});
-
-
-describe("similarity",  () => {
-
-    test("Empty strings",  () => {
-        const match = similarity("", "");
-        expect(match).toBe(1.0);
-    });
-
-    test("100%  Match",  () => {
-        const match = similarity('abc', 'abc');
-        expect(match).toBe(1);
-    });
-
-    test("No Match",  () => {
-        const match = similarity('abc', 'def');
-        expect(match).toBe(0);
-    });
-
-    test("Partial Match",  () => {
-        const match = similarity('abc', 'abdef');
-        expect(match).toBeTruthy();
     });
 });
 

--- a/tests/test_init/handler.test.js
+++ b/tests/test_init/handler.test.js
@@ -20,11 +20,12 @@ import {
     TEST_REPO_RESPONSE,
     TEST_USER,
     waitFor,
-    addUser
+    addUser,
+    writeTestRepoFiles
 } from "../helpers/helpers";
 import { SYNC_IGNORE_FILE_DATA } from "../../src/constants";
 import { pathUtils } from "../../src/utils/path_utils";
-import { readYML } from "../../src/utils/common";
+import { readYML, readFile } from "../../src/utils/common";
 import {createSystemDirectories} from "../../src/utils/setup_utils";
 
 describe("initHandler: connectRepo", () => {
@@ -129,7 +130,7 @@ describe("initHandler: connectRepo", () => {
         expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(0);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(0);
         expect(fs.existsSync(syncIgnorePath)).toBe(true);
-        const _syncIgnoreData = fs.readFileSync(syncIgnorePath, "utf8");
+        const _syncIgnoreData = readFile(syncIgnorePath);
         expect(_syncIgnoreData).toStrictEqual(SYNC_IGNORE_FILE_DATA);
         expect(vscode.workspace.openTextDocument).toHaveBeenCalledTimes(1);
     });
@@ -143,7 +144,7 @@ describe("initHandler: connectRepo", () => {
         // Verify error msg
         const syncIgnorePath = path.join(repoPath, SYNCIGNORE);
         expect(fs.existsSync(syncIgnorePath)).toBe(true);
-        const _syncIgnoreData = fs.readFileSync(syncIgnorePath, "utf8");
+        const _syncIgnoreData = readFile(syncIgnorePath);
         expect(_syncIgnoreData).toStrictEqual(SYNC_IGNORE_FILE_DATA);
         expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(0);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(0);
@@ -162,7 +163,7 @@ describe("initHandler: connectRepo", () => {
         // Verify error msg
         const syncIgnorePath = path.join(repoPath, SYNCIGNORE);
         expect(fs.existsSync(syncIgnorePath)).toBe(true);
-        const _syncIgnoreData = fs.readFileSync(syncIgnorePath, "utf8");
+        const _syncIgnoreData = readFile(syncIgnorePath);
         expect(_syncIgnoreData).toStrictEqual(gitignoreData);
         expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(0);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(0);
@@ -179,7 +180,7 @@ describe("initHandler: connectRepo", () => {
         const handler = new initHandler(repoPath, "ACCESS_TOKEN");
         await handler.connectRepo();
         expect(fs.existsSync(syncIgnorePath)).toBe(true);
-        const _syncIgnoreData = fs.readFileSync(syncIgnorePath, "utf8");
+        const _syncIgnoreData = readFile(syncIgnorePath);
         expect(_syncIgnoreData).toStrictEqual(syncIgnoreData);
         expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(0);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(0);
@@ -197,7 +198,7 @@ describe("initHandler: connectRepo", () => {
         await handler.connectRepo();
         // Verify .syncignore has been created
         expect(fs.existsSync(syncIgnorePath)).toBe(true);
-        const _syncIgnoreData = fs.readFileSync(syncIgnorePath, "utf8");
+        const _syncIgnoreData = readFile(syncIgnorePath);
         expect(_syncIgnoreData).toStrictEqual(syncIgnoreData);
         expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(0);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(0);
@@ -236,6 +237,7 @@ describe("initHandler: Syncing Branch", () => {
         userFilePath = getUserFilePath(baseRepoPath);
         sequenceTokenFilePath = getSeqTokenFilePath(baseRepoPath);
         fs.writeFileSync(configPath, yaml.safeDump(configData));
+        writeTestRepoFiles(repoPath);
     });
 
     afterEach(() => {

--- a/tests/test_init/utils.test.js
+++ b/tests/test_init/utils.test.js
@@ -14,7 +14,8 @@ import {
     TEST_REPO_RESPONSE,
     TEST_USER,
     randomBaseRepoPath,
-    randomRepoPath, getConfigFilePath, getSyncIgnoreFilePath, getUserFilePath, getSeqTokenFilePath, Config, addUser, waitFor
+    randomRepoPath, getConfigFilePath, getSyncIgnoreFilePath, getUserFilePath, getSeqTokenFilePath, Config, addUser, waitFor,
+    writeTestRepoFiles
 } from "../helpers/helpers";
 import {API_ROUTES, DEFAULT_BRANCH, VSCODE, NOTIFICATION, SYNCIGNORE} from "../../src/constants";
 import {readYML} from "../../src/utils/common";
@@ -57,17 +58,16 @@ describe("getSyncablePaths",  () => {
         fs.writeFileSync(syncIgnorePath, SYNC_IGNORE_DATA+"\nignore.js");
         const initUtilsObj = new initUtils(repoPath);
         const paths = initUtilsObj.getSyncablePaths();
-
         // 1 is .syncignore, other is file.js
         expect(paths).toHaveLength(2);
-        expect(paths[0].rel_path).toStrictEqual(SYNCIGNORE);
+        expect(paths[0].rel_path).toStrictEqual("file.js");
         expect(paths[0].is_binary).toBe(false);
-        expect(paths[0].file_path).toStrictEqual(syncIgnorePath);
-        expect(paths[0].size).toBeTruthy();
-        expect(paths[1].rel_path).toStrictEqual("file.js");
+        expect(paths[0].file_path).toStrictEqual(filePath);
+        expect(paths[0].size).toStrictEqual(0);
+        expect(paths[1].rel_path).toStrictEqual(SYNCIGNORE);
         expect(paths[1].is_binary).toBe(false);
-        expect(paths[1].file_path).toStrictEqual(filePath);
-        expect(paths[1].size).toStrictEqual(0);
+        expect(paths[1].file_path).toStrictEqual(syncIgnorePath);
+        expect(paths[1].size).toBeTruthy();
     });
 });
 
@@ -121,6 +121,7 @@ describe("copyFilesTo",  () => {
 
 describe("saveIamUser",  () => {
     const baseRepoPath = randomBaseRepoPath();
+    const repoPath = randomRepoPath();
     const userFilePath = getUserFilePath(baseRepoPath);
     const userFileData = {};
     userFileData[TEST_USER.email] = {
@@ -139,7 +140,7 @@ describe("saveIamUser",  () => {
     });
 
     test("With no user.yml",  () => {
-        const initUtilsObj = new initUtils();
+        const initUtilsObj = new initUtils(repoPath);
         initUtilsObj.saveIamUser(TEST_USER);
         expect(fs.existsSync(userFilePath)).toBe(true);
         const users = readYML(userFilePath);
@@ -149,7 +150,7 @@ describe("saveIamUser",  () => {
 
     test("With no active user.yml",  () => {
         addUser(baseRepoPath, false);
-        const initUtilsObj = new initUtils();
+        const initUtilsObj = new initUtils(repoPath);
         initUtilsObj.saveIamUser(TEST_USER);
         expect(fs.existsSync(userFilePath)).toBe(true);
         const users = readYML(userFilePath);
@@ -161,7 +162,7 @@ describe("saveIamUser",  () => {
         fs.writeFileSync(userFilePath, yaml.safeDump(userFileData));
         const testUser = Object.assign({}, TEST_USER);
         testUser.email = ANOTHER_TEST_EMAIL;
-        const initUtilsObj = new initUtils();
+        const initUtilsObj = new initUtils(repoPath);
         initUtilsObj.saveIamUser(testUser);
         expect(fs.existsSync(userFilePath)).toBe(true);
         const users = readYML(userFilePath);
@@ -176,7 +177,7 @@ describe("saveIamUser",  () => {
         fs.writeFileSync(userFilePath, yaml.safeDump(userFileData));
         const testUser = Object.assign({}, TEST_USER);
         testUser.email = TEST_EMAIL;
-        const initUtilsObj = new initUtils();
+        const initUtilsObj = new initUtils(repoPath);
         initUtilsObj.saveIamUser(testUser);
         expect(fs.existsSync(userFilePath)).toBe(true);
         const users = readYML(userFilePath);
@@ -188,6 +189,7 @@ describe("saveIamUser",  () => {
 
 describe("saveSequenceTokenFile",  () => {
     const baseRepoPath = randomBaseRepoPath();
+    const repoPath = randomRepoPath();
     const sequenceTokenFilePath = getSeqTokenFilePath(baseRepoPath);
     const sequenceTokenFileData = {};
     sequenceTokenFileData[TEST_EMAIL] = "";
@@ -203,7 +205,7 @@ describe("saveSequenceTokenFile",  () => {
     });
 
     test("With no sequence_token.yml",  () => {
-        const initUtilsObj = new initUtils();
+        const initUtilsObj = new initUtils(repoPath);
         initUtilsObj.saveSequenceTokenFile(TEST_EMAIL);
         expect(fs.existsSync(sequenceTokenFilePath)).toBe(true);
         const users = readYML(sequenceTokenFilePath);
@@ -211,7 +213,7 @@ describe("saveSequenceTokenFile",  () => {
     });
 
     test("User not in user.yml",  () => {
-        const initUtilsObj = new initUtils();
+        const initUtilsObj = new initUtils(repoPath);
         fs.writeFileSync(sequenceTokenFilePath, yaml.safeDump(sequenceTokenFileData));
         initUtilsObj.saveSequenceTokenFile(ANOTHER_TEST_EMAIL);
         expect(fs.existsSync(sequenceTokenFilePath)).toBe(true);
@@ -252,7 +254,6 @@ describe("uploadRepo",  () => {
     let baseRepoPath;
     let repoPath;
     let syncIgnorePath;
-    let filePath;
     let configPath;
     let userFilePath;
     let sequenceTokenFilePath;
@@ -267,20 +268,18 @@ describe("uploadRepo",  () => {
         // Create directories
         fs.mkdirSync(baseRepoPath, {recursive: true});
         fs.mkdirSync(repoPath, {recursive: true});
+        
         untildify.mockReturnValue(baseRepoPath);
         createSystemDirectories();
-
+        writeTestRepoFiles(repoPath);
         configPath = getConfigFilePath(baseRepoPath);
         userFilePath = getUserFilePath(baseRepoPath);
         sequenceTokenFilePath = getSeqTokenFilePath(baseRepoPath);
         syncIgnorePath = getSyncIgnoreFilePath(repoPath);
-        filePath = path.join(repoPath, "file.js");
-    
         const configUtil = new Config(repoPath, configPath);
         configUtil.addRepo();
         fs.writeFileSync(configPath, yaml.safeDump(configData));
         fs.writeFileSync(syncIgnorePath, SYNC_IGNORE_DATA+"\nignore.js");
-        fs.writeFileSync(filePath, DUMMY_FILE_CONTENT);
         fs.writeFileSync(path.join(repoPath, "ignore.js"), DUMMY_FILE_CONTENT);
     });
 
@@ -293,8 +292,8 @@ describe("uploadRepo",  () => {
         // Generate ItemPaths
         const initUtilsObj = new initUtils(repoPath);
         const itemPaths = initUtilsObj.getSyncablePaths();
-        // 1 is .syncignore, other is file.js
-        expect(itemPaths).toHaveLength(2);
+        // Files count from TEST_RESPONSE_DATA
+        expect(itemPaths).toHaveLength(3);
         // Mock response for checkServerDown
         fetchMock.mockResponseOnce(JSON.stringify({status: false}));
 
@@ -305,7 +304,8 @@ describe("uploadRepo",  () => {
         const config = readYML(configPath);
         expect(config.repos[repoPath].branches[DEFAULT_BRANCH]).toStrictEqual({
             ".syncignore": null,
-            "file.js": null,
+            "file_1.js": null,
+            "directory/file_2.js": null,
         });
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
@@ -314,8 +314,8 @@ describe("uploadRepo",  () => {
         // Generate ItemPaths
         const initUtilsObj = new initUtils(repoPath);
         const itemPaths = initUtilsObj.getSyncablePaths();
-        // 1 is .syncignore, other is file.js
-        expect(itemPaths).toHaveLength(2);
+        // Files count from TEST_RESPONSE_DATA
+        expect(itemPaths).toHaveLength(3);
         // Mock response for checkServerDown
         fetchMock
             .mockResponseOnce(JSON.stringify({status: true}))
@@ -361,15 +361,25 @@ describe("uploadRepo",  () => {
         configUtil.removeRepo();
         const initUtilsObj = new initUtils(repoPath);
         const itemPaths = initUtilsObj.getSyncablePaths();
-        // 1 is .syncignore, other is file.js
-        expect(itemPaths).toHaveLength(2);
+        // Files count from TEST_RESPONSE_DATA
+        expect(itemPaths).toHaveLength(3);
         // Mock response for checkServerDown
         fetchMock
             .mockResponseOnce(JSON.stringify({status: true}))
             .mockResponseOnce(JSON.stringify(TEST_REPO_RESPONSE));
-    
+
+        const filePaths = itemPaths.map(itemPath => itemPath.file_path);
+        const pathUtilsObj = new pathUtils(repoPath, DEFAULT_BRANCH);
+        // copy files to .originals repo
+        const originalsRepoBranchPath = pathUtilsObj.getOriginalsRepoBranchPath();
+        initUtilsObj.copyFilesTo(filePaths, originalsRepoBranchPath);
+        // copy files to .shadow repo
+        const shadowRepoBranchPath = pathUtilsObj.getShadowRepoBranchPath();
+        initUtilsObj.copyFilesTo(filePaths, shadowRepoBranchPath);
+            
         await initUtilsObj.uploadRepo(DEFAULT_BRANCH, "ACCESS_TOKEN", itemPaths,
             TEST_EMAIL, false);
+        await waitFor(3);
 
         // Verify file Ids have been added in config
         const config = readYML(configPath);
@@ -383,7 +393,7 @@ describe("uploadRepo",  () => {
         users = readYML(userFilePath);
         expect(users[TEST_USER.email].access_key).toStrictEqual(TEST_USER.iam_access_key);
         expect(users[TEST_USER.email].secret_key).toStrictEqual(TEST_USER.iam_secret_key);
-        // Verify error msg
+        // Verify notification msg
         expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
         expect(vscode.window.showInformationMessage.mock.calls[0][0]).toStrictEqual(NOTIFICATION.REPO_SYNCED);
         expect(vscode.window.showErrorMessage).toHaveBeenCalledTimes(0);
@@ -402,7 +412,7 @@ describe("uploadRepo",  () => {
         expect(body.source).toStrictEqual(VSCODE);
         expect(body.platform).toStrictEqual(os.platform());
         const files_data = JSON.parse(body.files_data);
-        [".syncignore", "file.js"].forEach(key => {
+        Object.keys(TEST_REPO_RESPONSE.file_path_and_id).forEach(key => {
             expect(files_data[key]).toBeTruthy();
         });
     });
@@ -414,8 +424,8 @@ describe("uploadRepo",  () => {
 
         const initUtilsObj = new initUtils(repoPath);
         const itemPaths = initUtilsObj.getSyncablePaths();
-        // 1 is .syncignore, other is file.js
-        expect(itemPaths).toHaveLength(2);
+        // Files count from TEST_RESPONSE_DATA
+        expect(itemPaths).toHaveLength(3);
         // Mock response for checkServerDown
         fetchMock
             .mockResponseOnce(JSON.stringify({status: true}))

--- a/tests/test_utils/common/getSkipRepos.test.js
+++ b/tests/test_utils/common/getSkipRepos.test.js
@@ -1,14 +1,15 @@
 import fs from "fs";
 import path from "path";
-import { getSkipRepos, getSyncIgnoreItems } from "../../../src/utils/common";
+import { getSkipPaths, getSyncIgnoreItems } from "../../../src/utils/common";
 import { getSyncIgnoreFilePath, randomRepoPath } from "../../helpers/helpers";
 import { IGNORABLE_DIRECTORIES } from "../../../src/constants";
 
 
-describe("getSkipRepos",  () => {
+describe("getSkipPaths",  () => {
     const repoPath = randomRepoPath();
     const syncIgnorePath = getSyncIgnoreFilePath(repoPath);
-    const syncIgnoreData = ".skip_repo_1\n\n\n.skip_repo_2\n";
+    const syncIgnoreData = ".skip_repo_1\n\n\n.skip_repo_2\n!.skip_repo_3";
+    const defaultSkipPaths = [...IGNORABLE_DIRECTORIES.map(ignoreDir => `${repoPath}/**/${ignoreDir}/**`)];
 
     beforeEach(() => {
         // Create directories
@@ -24,24 +25,25 @@ describe("getSkipRepos",  () => {
 
     test('skipRepos with .syncignore items', () => {
         fs.writeFileSync(syncIgnorePath, syncIgnoreData);
-        const syncIgnoreItems = getSyncIgnoreItems(repoPath);
-        const skippedRepos = getSkipRepos(repoPath, syncIgnoreItems);
-        expect(skippedRepos).toEqual([...IGNORABLE_DIRECTORIES, ...syncIgnoreItems]);
+        let syncIgnoreItems = getSyncIgnoreItems(repoPath);
+        const skippedRepos = getSkipPaths(repoPath, syncIgnoreItems);
+        const syncIgnoreItemsForGlob = syncIgnoreItems.map(item => `${repoPath}/${item}/**`);
+        expect(skippedRepos).toEqual([...defaultSkipPaths, ...syncIgnoreItemsForGlob]);
     });
 
     test('skipRepos with NO .syncignore, default values', () => {
-        const skippedRepos = getSkipRepos(repoPath, []);
-        expect(skippedRepos).toStrictEqual(IGNORABLE_DIRECTORIES);
+        const skippedRepos = getSkipPaths(repoPath, []);
+        expect(skippedRepos).toStrictEqual(defaultSkipPaths);
     });
 
     test('with non-existing .syncignore item', () => {
-        const skippedRepos = getSkipRepos(repoPath, ["directory"]);
-        expect(skippedRepos).toStrictEqual(IGNORABLE_DIRECTORIES);
+        const skippedRepos = getSkipPaths(repoPath, ["directory"]);
+        expect(skippedRepos).toStrictEqual(defaultSkipPaths);
     });
 
     test('with file in syncignore', () => {
-        const skippedRepos = getSkipRepos(repoPath, ["file.js"]);
-        expect(skippedRepos).toStrictEqual(IGNORABLE_DIRECTORIES);
+        fs.writeFileSync(syncIgnorePath, syncIgnoreData);
+        const skippedRepos = getSkipPaths(repoPath, ["file.js"]);
+        expect(skippedRepos).toStrictEqual(defaultSkipPaths);
     });
-
 });

--- a/tests/test_utils/common/getSyncIgnoreItems.test.js
+++ b/tests/test_utils/common/getSyncIgnoreItems.test.js
@@ -16,7 +16,9 @@ afterAll(() => {
 
 test('syncIgnore items with .syncignore', () => {
     fs.writeFileSync(syncIgnorePath, SYNC_IGNORE_DATA);
-    expect(getSyncIgnoreItems(repoPath)).toStrictEqual([".DS_Store", ".git", ".node_modules"]);
+    const syncIgnoreItems = getSyncIgnoreItems(repoPath);
+    const expectedItems = SYNC_IGNORE_DATA.split("\n").filter(item => item && !item.startsWith("!"));
+    expect(syncIgnoreItems).toStrictEqual(expectedItems);
     fs.rmSync(syncIgnorePath);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,6 +1684,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/string-similarity@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/string-similarity/-/string-similarity-4.0.0.tgz#8cc03d5d1baad2b74530fe6c7d849d5768d391ad"
+  integrity sha512-dMS4S07fbtY1AILG/RhuwmptmzK1Ql8scmAebOTJ/8iBtK/KI17NwGwKzu1uipjj8Kk+3mfPxum56kKZE93mzQ==
+
 "@types/untildify@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/untildify/-/untildify-4.0.0.tgz#48f51e62b38baf7244fa527eacd3d9f605540e14"
@@ -1695,13 +1700,6 @@
   version "1.74.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.74.0.tgz#4adc21b4e7f527b893de3418c21a91f1e503bdcd"
   integrity sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==
-
-"@types/walk@^2.3.0":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/walk/-/walk-2.3.1.tgz#985d9ddb2690c32e9b377548cec426918d7248c0"
-  integrity sha512-gEH9G1wA3xKfAgQmJJA/Kdk5Ne9xI1Gn/q2Dwfl06m7IsgEBUUBVzSVfbi9zf6KYL4xfA6tFtzOQk9p0vBzLDg==
-  dependencies:
-    "@types/node" "*"
 
 "@types/websocket@^1.0.4":
   version "1.0.5"
@@ -2099,6 +2097,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -2889,11 +2894,6 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-foreachasync@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
-  integrity sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw==
-
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
@@ -2989,6 +2989,16 @@ glob-parent@^5.1.2:
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.0.0.tgz#034ab2e93644ba702e769c3e0558143d3fbd1612"
+  integrity sha512-zmp9ZDC6NpDNLujV2W2n+3lH+BafIVZ4/ct+Yj3BMZTH/+bgm/eVjHzeFLwxJrrIGgjjS2eiQLlpurHsNlEAtQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    minimatch "^9.0.0"
+    minipass "^5.0.0"
+    path-scurry "^1.6.4"
 
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
@@ -3793,6 +3803,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.0.1.tgz#ac061ed291f8b9adaca2b085534bb1d3b61bef83"
+  integrity sha512-C8QsKIN1UIXeOs3iWmiZ1lQY+EnKDojWd37fXy1aSbJvH4iSma1uy2OWuoB3m4SYRli5+CUjDv3Dij5DVoetmg==
+
 macaddress@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.5.3.tgz#2b9d6832be934cb775749f30f57d6537184a2bda"
@@ -3873,6 +3888,18 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.0.tgz#bfc8e88a1c40ffd40c172ddac3decb8451503b56"
+  integrity sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
 ms@2.0.0:
   version "2.0.0"
@@ -4074,6 +4101,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.6.4.tgz#020a9449e5382a4acb684f9c7e1283bc5695de66"
+  integrity sha512-Qp/9IHkdNiXJ3/Kon++At2nVpnhRiPq/aSvQN+H3U1WZbvNRK0RIQK/o4HMqPoXjpuGJUEWpHSs6Mnjxqh3TQg==
+  dependencies:
+    lru-cache "^9.0.0"
+    minipass "^5.0.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -4487,6 +4522,11 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -4767,13 +4807,6 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
-
-walk@^2.3.14:
-  version "2.3.15"
-  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.15.tgz#1b4611e959d656426bc521e2da5db3acecae2424"
-  integrity sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==
-  dependencies:
-    foreachasync "^3.0.0"
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
- Optimized logic to traverse a repo using "[glob](https://www.npmjs.com/package/glob)" instead of "[walk](https://www.npmjs.com/package/walk)" 
    - "walk" was causing _High CPU Usage_ and _Maximun Recursion Depth Error_ in VSCode plugin to traverse over large repos
- Optimized logic to checkForRename using [string-similarity](https://www.npmjs.com/package/string-similarity)
    - Earlier logic was taking ~15s for comparing text of files of ~50KB. With "string-similarity" it is in miliseconds
- Fixed a bug in getting `PotentialMatchingFiles` for rename
    - Earlier it was checking against every file of the repo. Now it considers only those files from shadow repo that possess following properties:
        - Shadow file should not be ignorable from .syncignore
        - Actual file is not present for the shadow file
        - Relative path of shadow file should be present in config file
        - Shadow file should not be a binary file since we are going to match the text of files
        - Shadow file should not be empty
    - Also getting `PotentialMatchingFiles` only once per repo instead of once per file
- Improved logic of ignoring a path from .syncignore
    - Using common function everywhere for "[ignores](https://www.npmjs.com/package/ignore)" which ignores path depending on content of .syncignore
    - Improved logic to ignore DEFAULT-SKIP-DIRECTORIES wherever they are present in the project e.g. `node_modules` etc
    
    
 Testing Instructions
 - Try to connect a large repo and observe CPU usage and VSCode logs for performance issues
 - Try to rename some large file (both for IDE-events and non-IDE events) and make sure it is correctly handled as rename
 - Try to copy large number of files in a Connected Repo and make sure those files are uploaded and there is no error in the Logs for performance. 
 - Use different patterns in `.syncignore` such as `!tests/tests_data`, `coverage/*`, ".git" etc and make sure these patterens are ignored/included correctly by the plugin