### PR TITLE
Fixed skip patterns for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.2] - 2023-05-16
+- Fixed skip patterns for Windows
+
 ## [3.20.1] - 2023-05-15
-- Fixed glob patterns for Windows
+- Fixed glob patterns for Windows in reading a repo
 
 ## [3.20.0] - 2023-05-05
 - Fixed duplicate sending of diffs in case diffs are not processed within 5s

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "CodeSync",
   "description": "Stream code to the cloud. Save it forever. Play it back later. No commits needed.",
   "icon": "images/icon.png",
-  "version": "3.20.1",
+  "version": "3.20.2",
   "publisher": "codesync",
   "engines": {
     "vscode": "^1.32.0",

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from "path";
 import yaml from 'js-yaml';
 import ignore from 'ignore';
@@ -94,6 +95,9 @@ export const getSkipPaths = (repoPath: string, syncignoreItems: string[]) => {
 	Output of this is used by globSync to ignore given directories
 	That's why appending /**  at the end of each directory path
 	*/
+	if (os.platform() === 'win32') {
+		repoPath = repoPath.replace(/\\/g, "/");
+	}
 	const skipPaths = [...IGNORABLE_DIRECTORIES.map(ignoreDir => `${repoPath}/**/${ignoreDir}/**`)];
 	syncignoreItems.forEach((pattern) => {
 		for (const terminator of ["/", "/*", "/**"]) {
@@ -108,7 +112,7 @@ export const getSkipPaths = (repoPath: string, syncignoreItems: string[]) => {
 		if (!fs.existsSync(itemPath) || !fs.lstatSync(itemPath).isDirectory()) return;
 		const _pattern = `${repoPath}/${pattern}/**`;
 		// Make sure there are no duplicates
-		if (skipPaths.includes(_pattern )) return;
+		if (skipPaths.includes(_pattern)) return;
 		skipPaths.push(_pattern);
 	});
 	return skipPaths;

--- a/tests/test_utils/common/getSkipRepos.test.js
+++ b/tests/test_utils/common/getSkipRepos.test.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { getSkipPaths, getSyncIgnoreItems } from "../../../src/utils/common";
 import { getSyncIgnoreFilePath, randomRepoPath } from "../../helpers/helpers";
@@ -9,7 +10,8 @@ describe("getSkipPaths",  () => {
     const repoPath = randomRepoPath();
     const syncIgnorePath = getSyncIgnoreFilePath(repoPath);
     const syncIgnoreData = ".skip_repo_1/\n\n\nskip_repo_2/**\n!.skip_repo_3/*\n.skip_repo_4\file.js";
-    const defaultSkipPaths = [...IGNORABLE_DIRECTORIES.map(ignoreDir => `${repoPath}/**/${ignoreDir}/**`)];
+    const patternRepoPath = os.platform() === 'win32' ? repoPath.replace(/\\/g, "/") : repoPath;
+    const defaultSkipPaths = [...IGNORABLE_DIRECTORIES.map(ignoreDir => `${patternRepoPath}/**/${ignoreDir}/**`)];
 
     beforeEach(() => {
         // Create directories

--- a/tests/test_utils/common/getSkipRepos.test.js
+++ b/tests/test_utils/common/getSkipRepos.test.js
@@ -35,7 +35,7 @@ describe("getSkipPaths",  () => {
         let syncIgnoreItems = getSyncIgnoreItems(repoPath);
         const skippedRepos = getSkipPaths(repoPath, syncIgnoreItems);
         // skip_repo_4 is non existant
-        expect(skippedRepos.filter(x => !defaultSkipPaths.includes(x))).toEqual([".skip_repo_1/**", "skip_repo_2/**"].map(item => `${repoPath}/${item}`));
+        expect(skippedRepos.filter(x => !defaultSkipPaths.includes(x))).toEqual([".skip_repo_1/**", "skip_repo_2/**"].map(item => `${patternRepoPath}/${item}`));
         expect(skippedRepos.filter(x => !defaultSkipPaths.includes(x)).includes(".skip_repo_4")).toEqual(false);
     });
 


### PR DESCRIPTION
Test on all Windows/Linux/Mac:
- populateBuffer should skip `node_modules` and other ignorable directories, where ever they are present in the repo path