### PR TITLE
fix: Resetting state value if Lock is compromised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.0] - 2023-06-01
+- Using instance UUID to debug/verify if multiple instances are acquiring locks or same instance is running things multiple times
+- Added logging when an instance acquires lock
+- Added logging for populateBuffer for "Watching Repo" for debugging
+- When lock is compromised, resetting the state variable
+
 ## [3.21.0] - 2023-05-22
 - Using fs.unlink instead of fs.unlinkSync
 - Running 1 instance of populateBuffer, waiting before previous iteration is completed

--- a/src/codesyncd/populate_buffer.ts
+++ b/src/codesyncd/populate_buffer.ts
@@ -42,6 +42,7 @@ export const populateBuffer = async (viaDaemon=true) => {
 };
 
 export const populateBufferForMissedEvents = async (readyRepos: any) => {
+    const instanceUUID = CodeSyncState.get(CODESYNC_STATES.INSTANCE_UUID);
     const isRunning = CodeSyncState.get(CODESYNC_STATES.POPULATE_BUFFER_RUNNING);
     if (isRunning) return;
     CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_RUNNING, true);
@@ -64,7 +65,7 @@ export const populateBufferForMissedEvents = async (readyRepos: any) => {
                 const t1 = new Date().getTime();
                 const timeTook = (t1 - t0) / 1000;
                 if (timeTook > GLOB_TIME_TAKEN_THRESHOLD) {
-                    CodeSyncLogger.warning(`populateBuffer took=${timeTook}s for ${repoPath}, files=${obj.itemPaths.length}`);
+                    CodeSyncLogger.warning(`populateBuffer took=${timeTook}s for ${repoPath}, files=${obj.itemPaths.length}, uuid=${instanceUUID}`);
                 }
             }    
             const generateDiffForDeletedFilesKey = `${repoPath}:${branch}:generateDiffForDeletedFiles`;
@@ -162,7 +163,8 @@ class PopulateBuffer {
     }
 
     async populateBufferForRepo() {
-        console.log(`Watching Repo: ${this.repoPath}`);
+        const instanceUUID = CodeSyncState.get(CODESYNC_STATES.INSTANCE_UUID);
+        CodeSyncLogger.debug(`Watching Repo: ${this.repoPath}, uuid=${instanceUUID}`);
         const handler = new eventHandler(this.repoPath, "", true);
         for (const itemPath of this.itemPaths) {
             let isRename = false;

--- a/src/codesyncd/websocket/socket_client.ts
+++ b/src/codesyncd/websocket/socket_client.ts
@@ -16,6 +16,7 @@ import { getPlanLimitReached } from "../../utils/pricing_utils";
 import { CodeSyncState, CODESYNC_STATES } from "../../utils/state_utils";
 import { setDiffsBeingProcessed } from "../utils";
 
+
 let errorCount = 0;
 
 export class SocketClient {
@@ -63,7 +64,7 @@ export class SocketClient {
             const socketConnection = (global as any).socketConnection;
             if (!socketConnection) return;
             // Trigger onValidAuth for already connected socket
-            const webSocketEvents = new SocketEvents(this.statusBarItem, this.repoDiffs, this.accessToken);
+            const webSocketEvents = new SocketEvents(this.statusBarItem, this.repoDiffs, this.accessToken, canSendDiffs);
             webSocketEvents.onValidAuth();
         }
     };
@@ -84,7 +85,7 @@ export class SocketClient {
 
         this.client.on('connect', function (connection: any) {
             errorCount = 0;
-            that.registerConnectionEvents(connection);
+            that.registerConnectionEvents(connection, canSendDiffs);
         });
 
         let url = `${API_ROUTES.DIFFS_WEBSOCKET}&token=${this.accessToken}`;
@@ -94,7 +95,7 @@ export class SocketClient {
         this.client.connect(url);
     };
 
-    registerConnectionEvents = (connection: any) => {
+    registerConnectionEvents = (connection: any, canSendDiffs: boolean) => {
         // Set connection in global
         (global as any).socketConnection = connection;
         // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -113,7 +114,7 @@ export class SocketClient {
         });
 
         // Iterate repoDiffs and send to server
-        const webSocketEvents = new SocketEvents(this.statusBarItem, this.repoDiffs, this.accessToken);
+        const webSocketEvents = new SocketEvents(this.statusBarItem, this.repoDiffs, this.accessToken, canSendDiffs);
 
         connection.on('message', function (message: any) {
             try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,15 +7,20 @@ import {
 	createStatusBarItem,
 	registerCommands, 
 	setInitialContext, 
-	setupCodeSync 
+	setupCodeSync, 
+	uuidv4
 } from "./utils/setup_utils";
 import { pathUtils } from "./utils/path_utils";
 import { checkSubDir } from "./utils/common";
 import { recallDaemon } from "./codesyncd/codesyncd";
 import { CodeSyncLogger } from "./logger";
+import { CODESYNC_STATES, CodeSyncState } from './utils/state_utils';
 
 
 export async function activate(context: vscode.ExtensionContext) {
+	const uuid = uuidv4();
+	CodeSyncState.set(CODESYNC_STATES.INSTANCE_UUID, uuid);
+
 	try {
 		let repoPath = pathUtils.getRootPath();
 		await setupCodeSync(repoPath);
@@ -30,7 +35,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		const statusBarItem = createStatusBarItem(context);
 
 		if (repoPath) {
-			CodeSyncLogger.info(`Configured repo: ${repoPath}`);
+			CodeSyncLogger.info(`Configured repo: ${repoPath}, uuid=${uuid}`);
 			if (subDirResult.isSubDir) {
 				repoPath = subDirResult.parentRepo;
 				CodeSyncLogger.debug(`Parent repo: ${repoPath}`);
@@ -89,7 +94,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		// @ts-ignore
 		CodeSyncLogger.critical("Failed to activate extension", e.stack);
 	}
-	CodeSyncLogger.info("activated...");
+	CodeSyncLogger.info(`activated, uuid=${uuid}`);
 }
 
 export function deactivate(context: vscode.ExtensionContext) {

--- a/src/init/utils.ts
+++ b/src/init/utils.ts
@@ -248,8 +248,8 @@ export class initUtils {
 
 		// Set key here that Branch is being synced
 		CodeSyncState.set(syncingBranchKey, new Date().getTime());
-
-		CodeSyncLogger.info(`Uploading branch=${branch}, repo=${this.repoPath}`);
+		const instanceUUID = CodeSyncState.get(CODESYNC_STATES.INSTANCE_UUID);
+		CodeSyncLogger.info(`Uploading branch=${branch}, repo=${this.repoPath}, uuid=${instanceUUID}`);
 
 		const data = {
 			name: repoName,

--- a/src/utils/lock_utils.ts
+++ b/src/utils/lock_utils.ts
@@ -1,58 +1,83 @@
 import lockFile, { LockOptions } from 'proper-lockfile';
 import { generateSettings } from '../settings';
 import { CodeSyncState, CODESYNC_STATES } from './state_utils';
+import { CodeSyncLogger } from '../logger';
 
-const onCompromised = () => {
+const onCompromisedPopulateBuffer = () => {
+	CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, false);
+};
+
+const onCompromisedSendDiffs = () => {
+	CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, false);
+};
+
+const onCompromisedPricing = () => {
 	// Do nothing
 };
 
 export class LockUtils {
 	
 	settings: any;
-	lockOptions: LockOptions;
+	lockOptionsPopulateBuffer: LockOptions;
+	lockOptionsSendDiffs: LockOptions;
+	lockOptionsPricing: LockOptions;
 
 	constructor() {
         this.settings = generateSettings();
-		this.lockOptions = ((global as any).IS_CODESYNC_TEST_MODE) ? {onCompromised: onCompromised}: {};
+		this.lockOptionsPopulateBuffer = ((global as any).IS_CODESYNC_TEST_MODE) ? {onCompromised: onCompromisedPopulateBuffer}: {};
+		this.lockOptionsSendDiffs = ((global as any).IS_CODESYNC_TEST_MODE) ? {onCompromised: onCompromisedSendDiffs}: {};
+		this.lockOptionsPricing = ((global as any).IS_CODESYNC_TEST_MODE) ? {onCompromised: onCompromisedPricing}: {};
 	}
 
 	checkPopulateBufferLock () {
 		try {
-			return lockFile.checkSync(this.settings.POPULATE_BUFFER_LOCK_FILE);
+			const isAcquired = lockFile.checkSync(this.settings.POPULATE_BUFFER_LOCK_FILE);
+			if (!isAcquired) CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, false);
+			return isAcquired;
 		} catch (e) {
+			CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, false);
 			return false;
 		}
 	}
 
 	checkDiffsSendLock = () => {
 		try {
-			return lockFile.checkSync(this.settings.DIFFS_SEND_LOCK_FILE);
+			const isAcquired = lockFile.checkSync(this.settings.DIFFS_SEND_LOCK_FILE);
+			if (!isAcquired) CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, false);
+			return isAcquired;
 		} catch (e) {
+			CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, false);
 			return false;
 		}
 	};
 	
 	acquirePopulateBufferLock = () => {
 		try {
-			lockFile.lockSync(this.settings.POPULATE_BUFFER_LOCK_FILE, this.lockOptions);
+			lockFile.lockSync(this.settings.POPULATE_BUFFER_LOCK_FILE, this.lockOptionsPopulateBuffer);
 			CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, true);
+			const instanceUUID = CodeSyncState.get(CODESYNC_STATES.INSTANCE_UUID);
+			CodeSyncLogger.debug(`populateBufferLock acquired by uuid=${instanceUUID}`);			
 		} catch (e) {
+			CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, false);
 			// 
 		}    
 	};
 	
 	acquireSendDiffsLock = () => {	
 		try {
-			lockFile.lockSync(this.settings.DIFFS_SEND_LOCK_FILE, this.lockOptions);
+			lockFile.lockSync(this.settings.DIFFS_SEND_LOCK_FILE, this.lockOptionsSendDiffs);
 			CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, true);
+			const instanceUUID = CodeSyncState.get(CODESYNC_STATES.INSTANCE_UUID);
+			CodeSyncLogger.debug(`DiffsSendLock acquired by uuid=${instanceUUID}`);
 		} catch (e) {
-			// 
+			CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, false);
+			//
 		}
 	};
 
 	acquirePricingAlertLock () {
 		try {
-			lockFile.lockSync(this.settings.UPGRADE_PLAN_ALERT, this.lockOptions);
+			lockFile.lockSync(this.settings.UPGRADE_PLAN_ALERT, this.lockOptionsPricing);
 		} catch (e) {
 			// 
 		}

--- a/src/utils/setup_utils.ts
+++ b/src/utils/setup_utils.ts
@@ -264,3 +264,20 @@ export const createStatusBarItem = (context: vscode.ExtensionContext) => {
 	context.subscriptions.push(statusBarItem);
 	return statusBarItem;
 };
+
+// Ref: https://stackoverflow.com/a/8809472
+export const uuidv4 = () => {
+	let d = new Date().getTime();//Timestamp
+    let d2 = ((typeof performance !== 'undefined') && performance.now && (performance.now()*1000)) || 0;//Time in microseconds since page-load or 0 if unsupported
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        let r = Math.random() * 16;//random number between 0 and 16
+        if(d > 0){//Use timestamp until depleted
+            r = (d + r)%16 | 0;
+            d = Math.floor(d/16);
+        } else {//Use microseconds since page-load if supported
+            r = (d2 + r)%16 | 0;
+            d2 = Math.floor(d2/16);
+        }
+        return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+    });
+};

--- a/src/utils/state_utils.ts
+++ b/src/utils/state_utils.ts
@@ -13,7 +13,8 @@ export const CODESYNC_STATES = {
     CAN_AVAIL_TRIAL: "canAvailTrial",
     STATUS_BAR_ACTIVITY_ALERT_MSG: "statusBarActivityAlertMsg",
     WEBSOCKET_ERROR_OCCURRED_AT: "websocketErrorOccurredAt",
-    DIFFS_BEING_PROCESSED: "diffsBeingProcessed"
+    DIFFS_BEING_PROCESSED: "diffsBeingProcessed",
+    INSTANCE_UUID: "instanceUUID"
 };
 
 export class CodeSyncState {

--- a/tests/test_codesyncd/buffer_handler.test.js
+++ b/tests/test_codesyncd/buffer_handler.test.js
@@ -330,7 +330,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const handled = await webSocketEvents.onMessage({'type': 'abc'});
         expect(handled).toBe(false);
     });
@@ -341,7 +341,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -363,7 +363,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         let diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -383,7 +383,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -403,7 +403,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -433,7 +433,7 @@ describe("bufferHandler", () => {
         let handler = new bufferHandler(statusBarItem);
         let diffFiles = handler.getDiffFiles();
         let repoDiffs = handler.groupRepoDiffs(diffFiles);
-        let webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        let webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         let msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -464,7 +464,7 @@ describe("bufferHandler", () => {
         handler = new bufferHandler(statusBarItem);
         diffFiles = handler.getDiffFiles();
         repoDiffs = handler.groupRepoDiffs(diffFiles);
-        webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         handled = await webSocketEvents.onMessage(msg);
         expect(handled).toBe(true);
         expect(fs.existsSync(diffFilePathForChanges)).toBe(true);
@@ -501,7 +501,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -531,7 +531,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -552,7 +552,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({
@@ -589,7 +589,7 @@ describe("bufferHandler", () => {
         const handler = new bufferHandler(statusBarItem);
         const diffFiles = handler.getDiffFiles();
         const repoDiffs = handler.groupRepoDiffs(diffFiles);
-        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN");
+        const webSocketEvents = new SocketEvents(statusBarItem, repoDiffs, "ACCESS_TOKEN", true);
         const msg = {
             type: 'utf8',
             utf8Data: JSON.stringify({


### PR DESCRIPTION
- Using instance UUID to debug/verify if multiple instances are acquiring locks or same instance is running things multiple times
- Added logging when an instance acquires lock
- Added logging for populateBuffer for "Watching Repo" for debugging
- When lock is compromised, resetting the state variable

**Testing instructions**
- This can be tested with the marketplace version since we can open only 1 instance in debugging mode
- Open 3-4 instances of VSCode and observe logs
- Sleep your laptop/pc for some time and then make it active again
- Keep an eye on logs, only 1 instance should be running populateBuffer and SendDiffs via Daemon. 