### PR TITLE
Fixed an edge case with Lock compromisation if onCompromised is called right after acquiring lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.3] - 2023-06-02
+- Fixed an edge case with Lock compromisation if onCompromised is called right after acquiring lock
+
 ## [3.22.2] - 2023-06-01
 - Corrected command in package.json for "Disconnect parent repo"
 - Fixed onCompromised callback

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -188,3 +188,4 @@ export const PRICING_URL_PATH = "/pricing";
 export const RETRY_WEBSOCKET_CONNECTION_AFTER = 5 * 60 * 1000; // 1000 is for ms;
 export const GLOB_TIME_TAKEN_THRESHOLD = 2;
 export const UPDATE_SYNCIGNORE_AFTER = 7 * 24 * 60 * 60 * 1000;  // 1 week
+export const IGNORE_ACQUIRED_LOCK_TIMEOUT = 5 * 1000;

--- a/src/utils/lock_utils.ts
+++ b/src/utils/lock_utils.ts
@@ -7,6 +7,7 @@ import { IGNORE_ACQUIRED_LOCK_TIMEOUT } from '../constants';
 
 export class LockUtils {
 	
+	isTestMode: boolean;
 	settings: any;
 	lockOptionsPopulateBuffer: LockOptions;
 	lockOptionsDiffsSend: LockOptions;
@@ -15,6 +16,7 @@ export class LockUtils {
 	instanceUUID: string;
 
 	constructor() {
+		this.isTestMode = ((global as any).IS_CODESYNC_TEST_MODE);
         this.settings = generateSettings();
 		this.lockOptionsPopulateBuffer = {onCompromised: this.onCompromisedPopulateBuffer};
 		this.lockOptionsDiffsSend = {onCompromised: this.onCompromisedDiffsSend};
@@ -24,6 +26,7 @@ export class LockUtils {
 	}
 
 	onCompromisedPopulateBuffer = (err: any) => {
+		if (this.isTestMode) return;
 		CodeSyncLogger.debug(`populateBufferLock compromised, uuid=${this.instanceUUID}, error=${err}`);
 		const canIgnore = CodeSyncState.canSkipRun(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED_AT, IGNORE_ACQUIRED_LOCK_TIMEOUT);
 		if (canIgnore) return;
@@ -32,6 +35,7 @@ export class LockUtils {
 	};
 	
 	onCompromisedDiffsSend = (err: any) => {
+		if (this.isTestMode) return;
 		CodeSyncLogger.debug(`diffsSendLock compromised, uuid=${this.instanceUUID}, error=${err}`);
 		const canIgnore = CodeSyncState.canSkipRun(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED_AT, IGNORE_ACQUIRED_LOCK_TIMEOUT);
 		if (canIgnore) return;
@@ -40,6 +44,7 @@ export class LockUtils {
 	};
 	
 	onCompromisedPricing = (err: any) => {
+		if (this.isTestMode) return;
 		CodeSyncLogger.debug(`pricingLock compromised, uuid=${this.instanceUUID}, error=${err}`);
 	};
 	

--- a/src/utils/lock_utils.ts
+++ b/src/utils/lock_utils.ts
@@ -1,32 +1,41 @@
-import lockFile, { LockOptions } from 'proper-lockfile';
+import lockFile, { CheckOptions, LockOptions } from 'proper-lockfile';
 import { generateSettings } from '../settings';
 import { CodeSyncState, CODESYNC_STATES } from './state_utils';
 import { CodeSyncLogger } from '../logger';
+import { IGNORE_ACQUIRED_LOCK_TIMEOUT } from '../constants';
 
 
 export class LockUtils {
 	
 	settings: any;
 	lockOptionsPopulateBuffer: LockOptions;
-	lockOptionsSendDiffs: LockOptions;
+	lockOptionsDiffsSend: LockOptions;
 	lockOptionsPricing: LockOptions;
+	checkSyncOptions: CheckOptions;
 	instanceUUID: string;
 
 	constructor() {
         this.settings = generateSettings();
 		this.lockOptionsPopulateBuffer = {onCompromised: this.onCompromisedPopulateBuffer};
-		this.lockOptionsSendDiffs = {onCompromised: this.onCompromisedSendDiffs};
+		this.lockOptionsDiffsSend = {onCompromised: this.onCompromisedDiffsSend};
 		this.lockOptionsPricing = {onCompromised: this.onCompromisedPricing};
+		this.checkSyncOptions = {stale: 15000};
 		this.instanceUUID = CodeSyncState.get(CODESYNC_STATES.INSTANCE_UUID);
 	}
 
 	onCompromisedPopulateBuffer = (err: any) => {
 		CodeSyncLogger.debug(`populateBufferLock compromised, uuid=${this.instanceUUID}, error=${err}`);
+		const canIgnore = CodeSyncState.canSkipRun(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED_AT, IGNORE_ACQUIRED_LOCK_TIMEOUT);
+		if (canIgnore) return;
+		CodeSyncLogger.debug(`populateBufferLock: Resetting state value, uuid=${this.instanceUUID}`);
 		CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, false);
 	};
 	
-	onCompromisedSendDiffs = (err: any) => {
+	onCompromisedDiffsSend = (err: any) => {
 		CodeSyncLogger.debug(`diffsSendLock compromised, uuid=${this.instanceUUID}, error=${err}`);
+		const canIgnore = CodeSyncState.canSkipRun(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED_AT, IGNORE_ACQUIRED_LOCK_TIMEOUT);
+		if (canIgnore) return;
+		CodeSyncLogger.debug(`diffsSendLock: Resetting state value, uuid=${this.instanceUUID}`);
 		CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, false);
 	};
 	
@@ -36,7 +45,7 @@ export class LockUtils {
 	
 	checkPopulateBufferLock () {
 		try {
-			const isAcquired = lockFile.checkSync(this.settings.POPULATE_BUFFER_LOCK_FILE);
+			const isAcquired = lockFile.checkSync(this.settings.POPULATE_BUFFER_LOCK_FILE, this.checkSyncOptions);
 			if (!isAcquired) CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, false);
 			return isAcquired;
 		} catch (e) {
@@ -47,7 +56,7 @@ export class LockUtils {
 
 	checkDiffsSendLock = () => {
 		try {
-			const isAcquired = lockFile.checkSync(this.settings.DIFFS_SEND_LOCK_FILE);
+			const isAcquired = lockFile.checkSync(this.settings.DIFFS_SEND_LOCK_FILE, this.checkSyncOptions);
 			if (!isAcquired) CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, false);
 			return isAcquired;
 		} catch (e) {
@@ -59,6 +68,7 @@ export class LockUtils {
 	acquirePopulateBufferLock = () => {
 		try {
 			lockFile.lockSync(this.settings.POPULATE_BUFFER_LOCK_FILE, this.lockOptionsPopulateBuffer);
+			CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED_AT, new Date().getTime());
 			CodeSyncState.set(CODESYNC_STATES.POPULATE_BUFFER_LOCK_ACQUIRED, true);
 			CodeSyncLogger.debug(`populateBufferLock acquired by uuid=${this.instanceUUID}`);			
 		} catch (e) {
@@ -69,7 +79,8 @@ export class LockUtils {
 	
 	acquireSendDiffsLock = () => {	
 		try {
-			lockFile.lockSync(this.settings.DIFFS_SEND_LOCK_FILE, this.lockOptionsSendDiffs);
+			lockFile.lockSync(this.settings.DIFFS_SEND_LOCK_FILE, this.lockOptionsDiffsSend);
+			CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED_AT, new Date().getTime());
 			CodeSyncState.set(CODESYNC_STATES.DIFFS_SEND_LOCK_ACQUIRED, true);
 			CodeSyncLogger.debug(`DiffsSendLock acquired by uuid=${this.instanceUUID}`);
 		} catch (e) {

--- a/src/utils/state_utils.ts
+++ b/src/utils/state_utils.ts
@@ -5,6 +5,8 @@ export const CODESYNC_STATES = {
     IS_SYNCIGNORED_SUB_DIR: "isSyncIgnored",
 	DIFFS_SEND_LOCK_ACQUIRED: "diffsSendLockAcquired",
 	POPULATE_BUFFER_LOCK_ACQUIRED: "populateBufferLockAcquired",
+    DIFFS_SEND_LOCK_ACQUIRED_AT: "diffsSendLockAcquiredAt",
+    POPULATE_BUFFER_LOCK_ACQUIRED_AT: "populateBufferLockAcquiredAt",
     POPULATE_BUFFER_RUNNING: "populateBufferRunning",
     PRICING_URL: "pricingUrl",
     REQUEST_SENT_AT: "requestSentAt",


### PR DESCRIPTION
**Testing Instructions**
- Open multiple instances of VSCode, open console logs for all instances
- Only 1 instance should acquire locks
- Sleep laptop for few minutes and then wake it up
- Observe logs in all instances, if for some instance, logs are in following order  
![image](https://github.com/codesyncapp/codesync-vs/assets/9863016/93225ad5-e0ef-4176-8a19-74eb021a8188)

Make sure that instance is running populateBuffer and sendDiffs periodically. 
Earlier in this situation, no instance was able to acquire the locks. 