### PR TITLE
Listen for TabChangeEvent, format data and save in ~/.codesync/.tabs

### DIFF
--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -23,6 +23,7 @@ const window = {
     })),
     tabGroups: {
         all: jest.fn(),
+        onDidChangeTabs: jest.fn(),
   },
 };
 

--- a/__mocks__/vscode.js
+++ b/__mocks__/vscode.js
@@ -20,7 +20,10 @@ const window = {
     createTextEditorDecorationType: jest.fn(),
     showTextDocument: jest.fn(() => ({
         then: jest.fn()
-    }))
+    })),
+    tabGroups: {
+        all: jest.fn(),
+  },
 };
 
 Object.defineProperty(window, 'activeTextEditor', {

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -127,7 +127,7 @@ export class eventHandler {
 		this.handleChanges(filePath, currentText);
 	}
 
-	handleTabChangeEvent = (changeEvent: vscode.TabChangeEvent) => {
+	handleTabChangeEvent = (tab_data: object) => {
 		/*
 		The flow for handler will be as follows:
 			- For the current open repoPath, get the repo_id and from config File
@@ -136,26 +136,26 @@ export class eventHandler {
 				* Get the Relative Path of each file using repoPath
 				* Get the fileID using relative_path found in above step
 		*/
+
 		// For the current open repoPath, get the repo_id and from config File
 		const configJSON = readYML(this.settings.CONFIG_PATH);
 		const repo_id = configJSON.repos[this.repoPath].id;
+		console.log(`Repo ID: ${repo_id}`)
 		// Discard event if no repo_id found
 		if (!repo_id) return;
-		console.log('repo_id: ', repo_id)
-		console.log(`Tabs changed!`);
+
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;
-		// console.log("List of open tabs: ", open_tabs);
 		// Loop through tab groups
 		for (const tab_group of open_tabs) {
-			// console.log(`Displaying tab group:`, tab_group)
 			for (let tab of tab_group.tabs) {
 				console.log(`Displaying tabs: `, tab);
 				// Get path of tab
 				// @ts-ignore
-				let tab_path = tab.input.uri.path;
-				console.log(`The path of tab is: ${tab_path}`)
-				// Get file ID using path 
+				let tab_path = (tab.input.uri.path).split('/');
+				// Get file ID using path
+				let file_id = configJSON.repos[this.repoPath].branches[this.branch][tab_path[tab_path.length - 1]];
+				console.log("File ID: ", file_id);
 				
 			}
 		}

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -146,7 +146,19 @@ export class eventHandler {
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;
 		// console.log("List of open tabs: ", open_tabs);
-
+		// Loop through tab groups
+		for (const tab_group of open_tabs) {
+			// console.log(`Displaying tab group:`, tab_group)
+			for (let tab of tab_group.tabs) {
+				console.log(`Displaying tabs: `, tab);
+				// Get path of tab
+				// @ts-ignore
+				let tab_path = tab.input.uri.path;
+				console.log(`The path of tab is: ${tab_path}`)
+				// Get file ID using path 
+				
+			}
+		}
 		// Dump to <timestamp.yml>
 		// Storing current timestamp in current_timestamp 
 		// const current_timestamp = new Date().getTime();

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -152,7 +152,7 @@ export class eventHandler {
 				console.log(`Displaying tabs: `, tab);
 				// Get path of tab
 				// @ts-ignore
-				let tabPath = (tab.input.uri.path).split('/');
+				let tabPath = this.pathUtils.getTabPath(tab.input.uri.path);
 				// Get file ID using path
 				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, tabPath[tabPath.length - 1]);
 				console.log("File ID: ", fileId);

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -127,6 +127,32 @@ export class eventHandler {
 		this.handleChanges(filePath, currentText);
 	}
 
+	handleTabChangeEvent = (changeEvent: vscode.TabChangeEvent) => {
+		/*
+		The flow for handler will be as follows:
+			- For the current open repoPath, get the repo_id and from config File
+			- Get Current Open Tabs TabGroups.ALL
+			- For each tab:
+				* Get the Relative Path of each file using repoPath
+				* Get the fileID using relative_path found in above step
+		*/
+		// For the current open repoPath, get the repo_id and from config File
+		const configJSON = readYML(this.settings.CONFIG_PATH);
+		const repo_id = configJSON.repos[this.repoPath].id;
+		console.log('repo_id: ', repo_id)
+		console.log(`Tabs changed!`);
+		// Get list of current tabs
+		const open_tabs = vscode.window.tabGroups.all;
+		// console.log("List of open tabs: ", open_tabs);
+
+		// Dump to <timestamp.yml>
+		// Storing current timestamp in current_timestamp 
+		// const current_timestamp = new Date().getTime();
+		// Question: where to we mention file name
+		// fs.writeFileSync(this.settings.TABS_PATH, yaml.dump(configJSON));
+	}
+
+
 	handleChanges = (filePath: string, currentText: string) => {
 		if (!filePath.startsWith(this.repoPath)) return;
 		// If file does not exist, return

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -4,7 +4,7 @@ import yaml from "js-yaml";
 import vscode from 'vscode';
 import { globSync } from 'glob';
 
-import { IDiff } from "../interface";
+import { IDiff, ITab } from "../interface";
 import { initUtils } from "../init/utils";
 import { formatDatetime, getBranch, getDefaultIgnorePatterns, getSyncIgnoreItems, readFile, readYML, shouldIgnorePath } from "../utils/common";
 import { generateSettings } from "../settings";
@@ -137,7 +137,9 @@ export class eventHandler {
 				* Get the Relative Path of each file using repoPath
 				* Get the fileID using relative_path found in above step
 		*/
-
+		// Record timestamp
+		const created_at = new Date().getTime();
+		console.log("created_at: ", created_at);
 		// For the current open repoPath, get the repo_id and from config File
 		const configUtils = new ConfigUtils();
 		const repoId = configUtils.getRepoIdByPath(this.repoPath);
@@ -146,24 +148,36 @@ export class eventHandler {
 
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;
+		let tabs: any[] = [];
 		// Loop through tab groups
 		for (const tab_group of open_tabs) {
 			for (let tab of tab_group.tabs) {
-				console.log(`Displaying tabs: `, tab);
+				// console.log(`Displaying tabs: `, tab);
 				// Get path of tab
 				// @ts-ignore
-				let fileName = this.pathUtils.getFileRelativePath(tab.input.uri.path);
-				console.log("File Name: ", fileName);
+				let fileRelativePath = this.pathUtils.getFileRelativePath(tab.input.uri.path);
+				// console.log("File Name: ", fileRelativePath);
 				// Get file ID using path
-				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileName);
-				console.log("File ID: ", fileId);
+				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileRelativePath);
+				// console.log("File ID: ", fileId);
+				tabs.push({"file_id": fileId, "path": fileRelativePath});
 			}
 		}
+		const tabsYAML = yaml.dump(tabs);
+		// console.log("tabs: ", tabsYAML);
+		// Structuring tab data
+		if (!repoId) return
+		const newTab = <ITab>{};
+		newTab.repo_id = repoId;
+		newTab.created_at = formatDatetime(created_at);
+		// console.log("Created at: ", this.createdAt)
+		newTab.source = VSCODE;
+		newTab.file_name = `${new Date().getTime()}.yml`
+		newTab.tabs = tabsYAML;
+		// console.log("newTab: ", newTab);
+
 		// Dump to <timestamp.yml>
-		// Storing current timestamp in current_timestamp 
-		// const current_timestamp = new Date().getTime();
-		// Question: where to we mention file name
-		// fs.writeFileSync(this.settings.TABS_PATH, yaml.dump(configJSON));
+		fs.writeFileSync(this.settings.TABS_PATH, yaml.dump(newTab));
 	}
 
 

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -141,7 +141,7 @@ export class eventHandler {
 		// For the current open repoPath, get the repo_id and from config File
 		const configUtils = new ConfigUtils();
 		const repoId = configUtils.getRepoIdByPath(this.repoPath);
-		// console.log(`Repo ID: ${repoId}`)
+		console.log(`Repo ID: ${repoId}`)
 		const configJSON = configUtils.config;
 
 		// Get list of current tabs
@@ -152,9 +152,10 @@ export class eventHandler {
 				console.log(`Displaying tabs: `, tab);
 				// Get path of tab
 				// @ts-ignore
-				let tabPath = this.pathUtils.getTabPath(tab.input.uri.path);
+				let fileName = this.pathUtils.getFileRelativePath(tab.input.uri.path);
+				console.log("File Name: ", fileName);
 				// Get file ID using path
-				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, tabPath[tabPath.length - 1]);
+				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileName);
 				console.log("File ID: ", fileId);
 			}
 		}

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -4,7 +4,7 @@ import yaml from "js-yaml";
 import vscode from 'vscode';
 import { globSync } from 'glob';
 
-import { IDiff, ITab } from "../interface";
+import { IDiff } from "../interface";
 import { initUtils } from "../init/utils";
 import { formatDatetime, getBranch, getDefaultIgnorePatterns, getSyncIgnoreItems, readFile, readYML, shouldIgnorePath } from "../utils/common";
 import { generateSettings } from "../settings";

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -16,7 +16,6 @@ import { CODESYNC_STATES, CodeSyncState } from '../utils/state_utils';
 import gitCommitInfo from 'git-commit-info';
 import { RepoState } from '../utils/repo_state_utils';
 import { UserState } from '../utils/user_utils';
-import { ConfigUtils } from '../utils/config_utils';
 
 
 export class eventHandler {
@@ -127,59 +126,6 @@ export class eventHandler {
 		const currentText = changeEvent.document.getText();
 		this.handleChanges(filePath, currentText);
 	}
-
-	handleTabChangeEvent = () => {
-		/*
-		The flow for handler will be as follows:
-			- For the current open repoPath, get the repo_id and from config File
-			- Get Current Open Tabs TabGroups.ALL
-			- For each tab:
-				* Get the Relative Path of each file using repoPath
-				* Get the fileID using relative_path found in above step
-		*/
-		// Record timestamp
-		const created_at = new Date().getTime();
-		console.log("created_at: ", created_at);
-		// For the current open repoPath, get the repo_id and from config File
-		const configUtils = new ConfigUtils();
-		const repoId = configUtils.getRepoIdByPath(this.repoPath);
-		console.log(`Repo ID: ${repoId}`)
-		const configJSON = configUtils.config;
-
-		// Get list of current tabs
-		const open_tabs = vscode.window.tabGroups.all;
-		const tabs: any[] = [];
-		// Loop through tab groups
-		for (const tab_group of open_tabs) {
-			for (let tab of tab_group.tabs) {
-				// console.log(`Displaying tabs: `, tab);
-				// Get path of tab
-				// @ts-ignore
-				const fileRelativePath = this.pathUtils.getFileRelativePath(tab.input.uri.path);
-				// console.log("File Name: ", fileRelativePath);
-				// Get file ID using path
-				const fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileRelativePath);
-				// console.log("File ID: ", fileId);
-				tabs.push({"file_id": fileId, "path": fileRelativePath});
-			}
-		}
-		const tabsYAML = yaml.dump(tabs);
-		// console.log("tabs: ", tabsYAML);
-		// Structuring tab data
-		if (!repoId) return
-		const newTab = <ITab>{};
-		newTab.repo_id = repoId;
-		newTab.created_at = formatDatetime(created_at);
-		// console.log("Created at: ", this.createdAt)
-		newTab.source = VSCODE;
-		newTab.file_name = `${new Date().getTime()}.yml`
-		newTab.tabs = tabsYAML;
-		// console.log("newTab: ", newTab);
-
-		// Dump to <timestamp.yml>
-		fs.writeFileSync(this.settings.TABS_PATH, yaml.dump(newTab));
-	}
-
 
 	handleChanges = (filePath: string, currentText: string) => {
 		if (!filePath.startsWith(this.repoPath)) return;

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -16,6 +16,7 @@ import { CODESYNC_STATES, CodeSyncState } from '../utils/state_utils';
 import gitCommitInfo from 'git-commit-info';
 import { RepoState } from '../utils/repo_state_utils';
 import { UserState } from '../utils/user_utils';
+import { ConfigUtils } from '../utils/config_utils';
 
 
 export class eventHandler {
@@ -138,9 +139,10 @@ export class eventHandler {
 		*/
 
 		// For the current open repoPath, get the repo_id and from config File
+		const configUtils = new ConfigUtils();
+		const repoId = configUtils.getRepoIdByPath(this.repoPath);
+		console.log(`Repo ID: ${repoId}`)
 		const configJSON = readYML(this.settings.CONFIG_PATH);
-		const repo_id = configJSON.repos[this.repoPath].id;
-		console.log(`Repo ID: ${repo_id}`)
 		
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -127,7 +127,7 @@ export class eventHandler {
 		this.handleChanges(filePath, currentText);
 	}
 
-	handleTabChangeEvent = (tab_data: object) => {
+	handleTabChangeEvent = () => {
 		/*
 		The flow for handler will be as follows:
 			- For the current open repoPath, get the repo_id and from config File
@@ -141,9 +141,7 @@ export class eventHandler {
 		const configJSON = readYML(this.settings.CONFIG_PATH);
 		const repo_id = configJSON.repos[this.repoPath].id;
 		console.log(`Repo ID: ${repo_id}`)
-		// Discard event if no repo_id found
-		if (!repo_id) return;
-
+		
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;
 		// Loop through tab groups

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -141,7 +141,7 @@ export class eventHandler {
 		// For the current open repoPath, get the repo_id and from config File
 		const configUtils = new ConfigUtils();
 		const repoId = configUtils.getRepoIdByPath(this.repoPath);
-		console.log(`Repo ID: ${repoId}`)
+		// console.log(`Repo ID: ${repoId}`)
 		const configJSON = configUtils.config;
 
 		// Get list of current tabs
@@ -152,11 +152,10 @@ export class eventHandler {
 				console.log(`Displaying tabs: `, tab);
 				// Get path of tab
 				// @ts-ignore
-				let tab_path = (tab.input.uri.path).split('/');
+				let tabPath = (tab.input.uri.path).split('/');
 				// Get file ID using path
-				let file_id = configJSON.repos[this.repoPath].branches[this.branch][tab_path[tab_path.length - 1]];
-				console.log("File ID: ", file_id);
-				
+				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, tabPath[tabPath.length - 1]);
+				console.log("File ID: ", fileId);
 			}
 		}
 		// Dump to <timestamp.yml>

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -139,6 +139,8 @@ export class eventHandler {
 		// For the current open repoPath, get the repo_id and from config File
 		const configJSON = readYML(this.settings.CONFIG_PATH);
 		const repo_id = configJSON.repos[this.repoPath].id;
+		// Discard event if no repo_id found
+		if (!repo_id) return;
 		console.log('repo_id: ', repo_id)
 		console.log(`Tabs changed!`);
 		// Get list of current tabs

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -142,8 +142,8 @@ export class eventHandler {
 		const configUtils = new ConfigUtils();
 		const repoId = configUtils.getRepoIdByPath(this.repoPath);
 		console.log(`Repo ID: ${repoId}`)
-		const configJSON = readYML(this.settings.CONFIG_PATH);
-		
+		const configJSON = configUtils.config;
+
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;
 		// Loop through tab groups

--- a/src/events/event_handler.ts
+++ b/src/events/event_handler.ts
@@ -148,17 +148,17 @@ export class eventHandler {
 
 		// Get list of current tabs
 		const open_tabs = vscode.window.tabGroups.all;
-		let tabs: any[] = [];
+		const tabs: any[] = [];
 		// Loop through tab groups
 		for (const tab_group of open_tabs) {
 			for (let tab of tab_group.tabs) {
 				// console.log(`Displaying tabs: `, tab);
 				// Get path of tab
 				// @ts-ignore
-				let fileRelativePath = this.pathUtils.getFileRelativePath(tab.input.uri.path);
+				const fileRelativePath = this.pathUtils.getFileRelativePath(tab.input.uri.path);
 				// console.log("File Name: ", fileRelativePath);
 				// Get file ID using path
-				let fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileRelativePath);
+				const fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileRelativePath);
 				// console.log("File ID: ", fileId);
 				tabs.push({"file_id": fileId, "path": fileRelativePath});
 			}

--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -74,7 +74,6 @@ export class tabEventHandler {
 		// Dump data in the buffer
 		const tabFilePath = path.join(this.settings.TABS_PATH, this.newTab.file_name);
 		this.addToBuffer(tabFilePath);
-
 	}
 
 	addToBuffer = (tabFilePath: string) => {

--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -1,0 +1,81 @@
+import yaml from "js-yaml";
+import vscode from 'vscode';
+import fs from 'fs';
+
+import { VSCODE } from "../constants";
+import { ITab } from "../interface";
+import { formatDatetime, getBranch } from "../utils/common";
+import { ConfigUtils } from "../utils/config_utils";
+import { pathUtils } from "../utils/path_utils";
+import { generateSettings } from "../settings";
+import { RepoState } from "../utils/repo_state_utils";
+import { UserState } from "../utils/user_utils";
+
+export class tabEventHandler {
+	repoPath = "";
+	branch = "";
+	pathUtils: any;
+
+	// Diff props
+	settings = generateSettings();
+	shouldProceed = false;
+
+	constructor(repoPath="") {
+		const userState = new UserState();
+		const isValidAccount = userState.isValidAccount();
+		this.repoPath = repoPath || pathUtils.getRootPath();
+		const repoState = new RepoState(this.repoPath).get();
+		const repoIsConnected = repoState.IS_CONNECTED;
+		this.shouldProceed = isValidAccount && repoIsConnected;
+		if (!this.shouldProceed) return;
+		this.branch = getBranch(this.repoPath);
+		this.pathUtils = new pathUtils(this.repoPath, this.branch);
+	}
+
+	handleTabChangeEvent = () => {
+		// Record timestamp
+		const created_at = new Date().getTime();
+		// For the current open repoPath, get the repo_id and from config File
+		const configUtils = new ConfigUtils();
+		const repoId = configUtils.getRepoIdByPath(this.repoPath);
+		// console.log(`Repo ID: ${repoId}`)
+		const configJSON = configUtils.config;
+
+		// Get list of current tabs
+		const open_tabs = vscode.window.tabGroups.all;
+		const tabs: any[] = [];
+		// Loop through tab groups
+		for (const tab_group of open_tabs) {
+			for (let tab of tab_group.tabs) {
+				// console.log(`Displaying tabs: `, tab);
+				// Get path of tab
+				// @ts-ignore
+				const fileRelativePath = this.pathUtils.getFileRelativePath(tab.input.uri.path);
+				// console.log("File Name: ", fileRelativePath);
+				// Get file ID using path
+				const fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileRelativePath);
+				// console.log("File ID: ", fileId);
+				tabs.push({"file_id": fileId, "path": fileRelativePath});
+			}
+		}
+		const tabsJSON = JSON.stringify(tabs);
+		// Structuring tab data
+		if (!repoId) return
+		const newTab = <ITab>{};
+		newTab.repo_id = repoId;
+		newTab.created_at = formatDatetime(created_at);
+		newTab.source = VSCODE;
+		newTab.file_name = `${new Date().getTime()}.yml`
+		newTab.tabs = tabsJSON;
+		console.log("newTab: ", yaml.dump(newTab));
+
+		// Dump to <timestamp.yml>
+		fs.writeFileSync(this.settings.TABS_PATH, yaml.dump(newTab));
+	}
+
+	addToBuffer = () => {
+
+	}
+
+
+}

--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -27,6 +27,7 @@ export class tabEventHandler {
 		const userState = new UserState();
 		const isValidAccount = userState.isValidAccount();
 		this.repoPath = repoPath || pathUtils.getRootPath();
+		if(!this.repoPath) return;
 		const repoState = new RepoState(this.repoPath).get();
 		const repoIsConnected = repoState.IS_CONNECTED;
 		this.shouldProceed = isValidAccount && repoIsConnected;
@@ -40,7 +41,10 @@ export class tabEventHandler {
 		const created_at = new Date().getTime();
 		// For the current open repoPath, get the repo_id and from config File
 		const configUtils = new ConfigUtils();
+		console.log("repo path: ", this.repoPath);
 		const repoId = configUtils.getRepoIdByPath(this.repoPath);
+		console.log("repo id: ", repoId);
+		if (!repoId) return
 		// console.log(`Repo ID: ${repoId}`)
 		const configJSON = configUtils.config;
 
@@ -61,14 +65,12 @@ export class tabEventHandler {
 				tabs.push({"file_id": fileId, "path": fileRelativePath});
 			}
 		}
-		const tabsJSON = JSON.stringify(tabs);
 		// Structuring tab data
-		if (!repoId) return
 		this.newTab.repo_id = repoId;
 		this.newTab.created_at = formatDatetime(created_at);
 		this.newTab.source = VSCODE;
 		this.newTab.file_name = `${new Date().getTime()}.yml`
-		this.newTab.tabs = tabsJSON;
+		this.newTab.tabs = tabs;
 		console.log("newTab: ", yaml.dump(this.newTab));
 
 		// Dump data in the buffer
@@ -78,6 +80,7 @@ export class tabEventHandler {
 
 	addToBuffer = (tabFilePath: string) => {
 		try {
+			if (!tabFilePath) return;
 			fs.writeFileSync(tabFilePath, yaml.dump(this.newTab));
 		} catch (e) {
 			CodeSyncLogger.error(`Error while dumping tab data: ${e}`);

--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -24,11 +24,14 @@ export class tabEventHandler {
 	constructor(repoPath="") {
 		const userState = new UserState();
 		const isValidAccount = userState.isValidAccount();
+		console.log("is valid account: ", isValidAccount);
 		this.repoPath = repoPath || pathUtils.getRootPath();
 		if(!this.repoPath) return;
 		const repoState = new RepoState(this.repoPath).get();
 		const repoIsConnected = repoState.IS_CONNECTED;
+		console.log("repoIsConnected: ", repoIsConnected)
 		this.shouldProceed = isValidAccount && repoIsConnected;
+		console.log("this.shouldProceed: ", this.shouldProceed);
 		if (!this.shouldProceed) return;
 		this.branch = getBranch(this.repoPath);
 		this.pathUtils = new pathUtils(this.repoPath, this.branch);
@@ -37,8 +40,9 @@ export class tabEventHandler {
 	handleTabChangeEvent = (isTabEvent: boolean) => {
 		if(!this.repoPath) return;
 		// Discard event if file is changed 
+		console.log("Just before check");
 		if (!isTabEvent) return;
-
+		console.log("Just after check");
 		// Record timestamp
 		const created_at = formatDatetime(new Date().getTime());
 		// For the current open repoPath, get the repo_id and from config File

--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -37,7 +37,7 @@ export class tabEventHandler {
 		this.pathUtils = new pathUtils(this.repoPath, this.branch);
 	}
 
-	handleTabChangeEvent = (isTabEvent: boolean) => {
+	handleTabChangeEvent = (isTabEvent: boolean = true) => {
 		if(!this.repoPath) return;
 		// Discard event if file is changed 
 		console.log("Just before check");

--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -52,7 +52,7 @@ export class tabEventHandler {
 				const fileRelativePath = tab.input.uri.path;
 				// Get file ID using path
 				const fileId = configUtils.getFileIdByPath(this.repoPath, this.branch, fileRelativePath);
-				return {file_id: fileId || null, path: fileRelativePath};
+				return {file_id: fileId, path: fileRelativePath};
 			})
 		);
 		// Adding to buffer

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			// Capturing initial tabs
 			const handler = new tabEventHandler(repoPath);
-			handler.handleTabChangeEvent(true);
+			handler.handleTabChangeEvent();
 		}
 
 		// Register tab change event

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,17 +37,22 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (RepoState.isSubDir()) {
 				repoPath = RepoState.getParentRepo();
 				CodeSyncLogger.debug(`Parent repo: ${repoPath}`);
-			}	
+			}
+			// Capturing initial tabs
+			const handler = new eventHandler(repoPath);
+			handler.handleTabChangeEvent();
 		}
 
 		// Register tab change event
 		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
 			try {
-				const tab_data = vscode.window.tabGroups.all;
+				// Discard event if repo is not opened
+				if (!repoPath) return;
 				// Discard event if file is changed 
 				if (changeEvent.changed.length > 0) return;
+
 				const handler = new eventHandler(repoPath);
-				handler.handleTabChangeEvent(tab_data);
+				handler.handleTabChangeEvent();
 			} catch (e) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { recallDaemon } from "./codesyncd/codesyncd";
 import { CodeSyncLogger } from "./logger";
 import { CODESYNC_STATES, CodeSyncState } from './utils/state_utils';
 import { RepoState } from './utils/repo_state_utils';
+import { tabEventHandler } from './events/tab_event_handler';
 
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -39,7 +40,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				CodeSyncLogger.debug(`Parent repo: ${repoPath}`);
 			}
 			// Capturing initial tabs
-			const handler = new eventHandler(repoPath);
+			const handler = new tabEventHandler(repoPath);
 			handler.handleTabChangeEvent();
 		}
 
@@ -51,7 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				// Discard event if file is changed 
 				if (changeEvent.changed.length > 0) return;
 
-				const handler = new eventHandler(repoPath);
+				const handler = new tabEventHandler(repoPath);
 				handler.handleTabChangeEvent();
 			} catch (e) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,19 @@ export async function activate(context: vscode.ExtensionContext) {
 				CodeSyncLogger.debug(`Parent repo: ${repoPath}`);
 			}	
 		}
+
+		// Register tab change event
+		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
+			try {
+				const handler = new eventHandler(repoPath);
+				handler.handleTabChangeEvent(changeEvent);
+			} catch (e) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				CodeSyncLogger.error("Failed handling tabChangeEvent", e.stack);
+			}
+		})
+
 		// Register workspace events
 		vscode.workspace.onDidChangeTextDocument(changeEvent => {
 			try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		// Register tab change event
 		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
 			try {
-				const isTabEvent = changeEvent.changed.length == 0
+				const isTabEvent = changeEvent.changed.length == 0 && (changeEvent.opened.length > 0 || changeEvent.closed.length > 0)				
 				const handler = new tabEventHandler(repoPath);
 				handler.handleTabChangeEvent(isTabEvent);
 			} catch (e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,8 +43,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		// Register tab change event
 		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
 			try {
+				const tab_data = vscode.window.tabGroups.all;
+				// Discard event if file is changed 
+				if (changeEvent.changed.length > 0) return;
 				const handler = new eventHandler(repoPath);
-				handler.handleTabChangeEvent(changeEvent);
+				handler.handleTabChangeEvent(tab_data);
 			} catch (e) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,19 +41,15 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 			// Capturing initial tabs
 			const handler = new tabEventHandler(repoPath);
-			handler.handleTabChangeEvent();
+			handler.handleTabChangeEvent(true);
 		}
 
 		// Register tab change event
 		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
 			try {
-				// Discard event if repo is not opened
-				if (!repoPath) return;
-				// Discard event if file is changed 
-				if (changeEvent.changed.length > 0) return;
-
+				const isTabEvent = changeEvent.changed.length == 0
 				const handler = new tabEventHandler(repoPath);
-				handler.handleTabChangeEvent();
+				handler.handleTabChangeEvent(isTabEvent);
 			} catch (e) {
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 				// @ts-ignore

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,19 +44,6 @@ export async function activate(context: vscode.ExtensionContext) {
 			handler.handleTabChangeEvent();
 		}
 
-		// Register tab change event
-		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
-			try {
-				const isTabEvent = changeEvent.changed.length == 0 && (changeEvent.opened.length > 0 || changeEvent.closed.length > 0)				
-				const handler = new tabEventHandler(repoPath);
-				handler.handleTabChangeEvent(isTabEvent);
-			} catch (e) {
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				CodeSyncLogger.error("Failed handling tabChangeEvent", e.stack);
-			}
-		})
-
 		// Register workspace events
 		vscode.workspace.onDidChangeTextDocument(changeEvent => {
 			try {
@@ -101,6 +88,19 @@ export async function activate(context: vscode.ExtensionContext) {
 				CodeSyncLogger.error("Failed handling renameEvent", e.stack);
 			}
 		});
+
+		// Register tab change event
+		vscode.window.tabGroups.onDidChangeTabs(changeEvent => {
+			try {
+				const isTabEvent = changeEvent.changed.length == 0 && (changeEvent.opened.length > 0 || changeEvent.closed.length > 0)				
+				const handler = new tabEventHandler(repoPath);
+				handler.handleTabChangeEvent(isTabEvent);
+			} catch (e) {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				CodeSyncLogger.error("Failed handling tabChangeEvent", e.stack);
+			}
+		})
 
 		// Do not run daemon in case of tests
 		if ((global as any).IS_CODESYNC_TEST_MODE) return;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -16,7 +16,7 @@ export interface IDiff {
 
 export interface ITab {
 	repo_id: number;
-	created_at: number;
+	created_at: string;
 	source: string;
 	file_name: string;
 	tabs: string;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -19,7 +19,7 @@ export interface ITab {
 	created_at: string;
 	source: string;
 	file_name: string;
-	tabs: string;
+	tabs: any[];
 }
 
 export interface IRepoDiffs {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,6 +14,14 @@ export interface IDiff {
 	is_deleted?: boolean;
 }
 
+export interface ITab {
+	repo_id: number;
+	created_at: number;
+	source: string;
+	file_name: string;
+	tabs: string;
+}
+
 export interface IRepoDiffs {
 	repoPath: string;
 	file_to_diff: IFileToDiff[];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -22,6 +22,11 @@ export interface ITab {
 	tabs: any[];
 }
 
+export interface ITabFile {
+	file_id: number | null;
+	path: string;
+}
+
 export interface IRepoDiffs {
 	repoPath: string;
 	file_to_diff: IFileToDiff[];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -19,7 +19,7 @@ export interface ITab {
 	created_at: string;
 	source: string;
 	file_name: string;
-	tabs: any[];
+	tabs: ITabFile[];
 }
 
 export interface ITabFile {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -54,6 +54,7 @@ export const generateSettings = () => {
             Note: Above lock files do not contain any data. It depends on the process which acquires the lock. 
         .originals/
         .shadow/
+        .tabs/
         alerts.yml (Keeps track of different kind of alerts shown to user)
         config.yml 
         sequence_token.yml 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,6 +74,7 @@ export const generateSettings = () => {
         USER_PATH: path.join(rootRepo, "user.yml"),
         SEQUENCE_TOKEN_PATH: path.join(rootRepo, "sequence_token.yml"),
         SYNCIGNORE_PATH: path.join(rootRepo, "syncignore.yml"),
+        TABS_PATH: path.join(rootRepo, ".tabs")
     };
     // Lock Files
     const lockFiles = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import path from "path";
 import untildify from "untildify";
 
 // Set this to true for Development
-const DEBUG = false;
+const DEBUG = true;
 const useStaging = false;
 const DevConfig = {
     ROOT_REPO: useStaging ? '~/.codesync-staging': '~/.codesync-local',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import path from "path";
 import untildify from "untildify";
 
 // Set this to true for Development
-const DEBUG = true;
+const DEBUG = false;
 const useStaging = false;
 const DevConfig = {
     ROOT_REPO: useStaging ? '~/.codesync-staging': '~/.codesync-local',

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -35,7 +35,8 @@ export class ConfigUtils {
 		if (!this.isConfigValid()) return null;
 		const repoBranchConfig = this.config.repos[repoPath].branches[branchName];
 		if (!repoBranchConfig) return null;
-		return repoBranchConfig[fileName.split(`${repoPath}${path.sep}`)[1]];
+		const fileRelPath = fileName.split(`${repoPath}${path.sep}`)[1];
+		return repoBranchConfig[fileRelPath] || null;
 	}
 }
 

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -32,9 +32,9 @@ export class ConfigUtils {
 
 	getFileIdByPath = (repoPath: string, branchName: string, fileName: string): number | null => {
 		if (!this.isConfigValid()) return null;
-		const repoConfig = this.config.repos[repoPath].branches[branchName];
-		if (!repoConfig) return null;
-		return repoConfig[fileName];
+		const repoBranchConfig = this.config.repos[repoPath].branches[branchName];
+		if (!repoBranchConfig) return null;
+		return repoBranchConfig[fileName];
 	}
 }
 

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { generateSettings } from "../settings";
 import { readYML } from "./common";
+import path from 'path';
 
 export class ConfigUtils {
 	config: any;
@@ -34,7 +35,7 @@ export class ConfigUtils {
 		if (!this.isConfigValid()) return null;
 		const repoBranchConfig = this.config.repos[repoPath].branches[branchName];
 		if (!repoBranchConfig) return null;
-		return repoBranchConfig[fileName];
+		return repoBranchConfig[fileName.split(`${repoPath}${path.sep}`)[1]];
 	}
 }
 

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -27,10 +27,20 @@ export class ConfigUtils {
 		if (!this.isConfigValid()) return null;
 		const path: string | undefined = Object.keys(this.config.repos).find(path => {
 			const _repoConfig = this.config.repos[path];
-			return _repoConfig.id == this.config.repos[repoPath].id
+			return _repoConfig.id == this.config.repos[repoPath].id;
 		})
 		// @ts-ignore
 		return this.config.repos[path].id || null;
+	}
+
+	getFileIdByPath = (repoPath: string, branchName: string, fileName: string): number | null => {
+		if (!this.isConfigValid()) return null;
+		const path: string | undefined = Object.keys(this.config.repos).find(path => {
+			const _repoConfig = this.config.repos[path].branches[branchName];
+			return _repoConfig[fileName] == this.config.repos[repoPath].branches[branchName][fileName];
+		})
+		// @ts-ignore
+		return this.config.repos[path].branches[branchName][fileName];
 	}
 }
 

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -25,7 +25,7 @@ export class ConfigUtils {
 
 	getRepoIdByPath = (repoPath: string): number | null => {
 		if (!this.isConfigValid()) return null;
-		const repoConfig = this.config.repos[repoPath];
+		const repoConfig = this.config.repos[repoPath]; 
 		if (!repoConfig) return null;
 		return repoConfig.id;
 	}

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -25,22 +25,16 @@ export class ConfigUtils {
 
 	getRepoIdByPath = (repoPath: string): number | null => {
 		if (!this.isConfigValid()) return null;
-		const path: string | undefined = Object.keys(this.config.repos).find(path => {
-			const _repoConfig = this.config.repos[path];
-			return _repoConfig.id == this.config.repos[repoPath].id;
-		})
-		// @ts-ignore
-		return this.config.repos[path].id || null;
+		const repoConfig = this.config.repos[repoPath];
+		if (!repoConfig) return null;
+		return repoConfig.id;
 	}
 
 	getFileIdByPath = (repoPath: string, branchName: string, fileName: string): number | null => {
 		if (!this.isConfigValid()) return null;
-		const path: string | undefined = Object.keys(this.config.repos).find(path => {
-			const _repoConfig = this.config.repos[path].branches[branchName];
-			return _repoConfig[fileName] == this.config.repos[repoPath].branches[branchName][fileName];
-		})
-		// @ts-ignore
-		return this.config.repos[path].branches[branchName][fileName];
+		const repoConfig = this.config.repos[repoPath].branches[branchName];
+		if (!repoConfig) return null;
+		return repoConfig[fileName];
 	}
 }
 

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -22,4 +22,15 @@ export class ConfigUtils {
 		});
 		return repoPath || "";
 	}
+
+	getRepoIdByPath = (repoPath: string): number | null => {
+		if (!this.isConfigValid()) return null;
+		const path: string | undefined = Object.keys(this.config.repos).find(path => {
+			const _repoConfig = this.config.repos[path];
+			return _repoConfig.id == this.config.repos[repoPath].id
+		})
+		// @ts-ignore
+		return this.config.repos[path].id || null;
+	}
 }
+

--- a/src/utils/config_utils.ts
+++ b/src/utils/config_utils.ts
@@ -25,9 +25,9 @@ export class ConfigUtils {
 
 	getRepoIdByPath = (repoPath: string): number | null => {
 		if (!this.isConfigValid()) return null;
-		const repoConfig = this.config.repos[repoPath]; 
-		if (!repoConfig) return null;
-		return repoConfig.id;
+		const repoBranchConfig = this.config.repos[repoPath]; 
+		if (!repoBranchConfig) return null;
+		return repoBranchConfig.id;
 	}
 
 	getFileIdByPath = (repoPath: string, branchName: string, fileName: string): number | null => {

--- a/src/utils/path_utils.ts
+++ b/src/utils/path_utils.ts
@@ -38,10 +38,6 @@ export class pathUtils {
         return repoPath.replace(":", "");
     };
 
-    getFileRelativePath  = (tabPath: string): string => {
-        return tabPath.split(`${this.repoPath}${path.sep}`)[1];
-    };
-
     getOriginalsRepoPath = () => {
         return path.join(this.settings.ORIGINALS_REPO, this.formattedRepoPath);
     };
@@ -68,6 +64,10 @@ export class pathUtils {
 
     getDiffsRepo = () => {
         return this.settings.DIFFS_REPO;
+    }
+
+    getTabsRepo = () => {
+        return this.settings.TABS_PATH;
     }
 
     static getS3UploaderRepo = () => {

--- a/src/utils/path_utils.ts
+++ b/src/utils/path_utils.ts
@@ -38,12 +38,8 @@ export class pathUtils {
         return repoPath.replace(":", "");
     };
 
-    getTabPath = (tabPath: string): string[] => {
-        // For Windows path
-        if (tabPath.includes("\\")) {
-            return tabPath.split("\\");
-        }
-        return tabPath.split('/');
+    getFileRelativePath  = (tabPath: string): string => {
+        return tabPath.split(`${this.repoPath}${path.sep}`)[1];
     };
 
     getOriginalsRepoPath = () => {

--- a/src/utils/path_utils.ts
+++ b/src/utils/path_utils.ts
@@ -38,6 +38,14 @@ export class pathUtils {
         return repoPath.replace(":", "");
     };
 
+    getTabPath = (tabPath: string): string[] => {
+        // For Windows path
+        if (tabPath.includes("\\")) {
+            return tabPath.split("\\");
+        }
+        return tabPath.split('/');
+    };
+
     getOriginalsRepoPath = () => {
         return path.join(this.settings.ORIGINALS_REPO, this.formattedRepoPath);
     };

--- a/src/utils/setup_utils.ts
+++ b/src/utils/setup_utils.ts
@@ -47,7 +47,8 @@ export const createSystemDirectories = () => {
 		settings.SHADOW_REPO,
 		settings.DELETED_REPO,
 		settings.LOCKS_REPO,
-		settings.S3_UPLOADER
+		settings.S3_UPLOADER,
+		settings.TABS_PATH,
 	].forEach(directoryPath => {
 		// Create directory if does not exist
 		if (!fs.existsSync(directoryPath)) fs.mkdirSync(directoryPath, { recursive: true });

--- a/tests/extension.test.js
+++ b/tests/extension.test.js
@@ -152,6 +152,8 @@ describe("Extension: activate", () => {
         expect(vscode.workspace.onDidCreateFiles).toHaveBeenCalledTimes(1);
         // onDidRenameFiles
         expect(vscode.workspace.onDidRenameFiles).toHaveBeenCalledTimes(1);
+        // tabGroups.onDidChangeTabs
+        expect(vscode.window.tabGroups.onDidChangeTabs).toHaveBeenCalledTimes(1);
     });
 
     test("setupCodeSync: Fresh Setup, no user, no repo opened", async () => {

--- a/tests/test_events/handler/addTab.test.js
+++ b/tests/test_events/handler/addTab.test.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import vscode from 'vscode'
 import untildify from "untildify";
 import {DATETIME_FORMAT, DEFAULT_BRANCH} from "../../../src/constants";
 import {
@@ -34,7 +35,8 @@ describe("addTab", () => {
 
     const pathUtilsObj = new pathUtils(repoPath, DEFAULT_BRANCH);
     const tabsRepo = pathUtilsObj.getTabsRepo();
-    const newFilePath = path.join(repoPath, "new.js");
+    const newFilePath1 = path.join(repoPath, "new1.js");
+    const newFilePath2 = path.join(repoPath, "new2.js");
 
     beforeEach(() => {
         // Create directories
@@ -51,11 +53,6 @@ describe("addTab", () => {
     afterEach(() => {
         fs.rmSync(repoPath, { recursive: true, force: true });
         fs.rmSync(baseRepoPath, { recursive: true, force: true });
-    });
-
-    test('untildify should return the correct mocked path', () => {
-        untildify.mockReturnValue(baseRepoPath);
-        expect(untildify()).toBe(baseRepoPath);
     });
     
     // Skips case when repo exists
@@ -118,32 +115,18 @@ describe("addTab", () => {
     })
 
     test("Tabs data in positive case", async () => {
-
-        jest.mock('vscode', () => {
-            return {
-              window: {
-                tabGroups: {
-                    all: jest.fn(),
-              },
-            },
-            };
-          });
-          
-        const vscode = require('vscode');
         const mockTabGroups = [
             { 
                 tabs: [
-                    { file_id: 1, path: 'home/documents/user/file1.txt' },
-                    { file_id: 2, path: 'home/documents/user/file2.txt' },
+                    { file_id: 1, path: `${newFilePath1}` },
+                    { file_id: 2, path: `${newFilePath2}` },
                 ],
                 activeTab: { id: 1 } 
             }
         ];
         const spy = jest.spyOn(vscode.window.tabGroups, 'all').mockReturnValue(mockTabGroups);    
         const result = vscode.window.tabGroups.all();
-
         expect(result).toEqual(mockTabGroups);
-        expect(spy).toHaveBeenCalled();
         expect(result[0].tabs).toHaveLength(2);
         for (const tab of result[0].tabs) {
             expect(tab['file_id']).toBeDefined();

--- a/tests/test_events/handler/addTab.test.js
+++ b/tests/test_events/handler/addTab.test.js
@@ -34,7 +34,7 @@ describe("addTab", () => {
     const pathUtilsObj = new pathUtils(repoPath, DEFAULT_BRANCH);
     const tabsRepo = pathUtilsObj.getTabsRepo();
     const newFilePath1 = path.join(repoPath, "file_1.js");
-    const newFilePath2 = path.join(repoPath, "new2.js");
+    const newFilePath2 = path.join(repoPath, "directory", "documents", "new2.js");
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -42,10 +42,8 @@ describe("addTab", () => {
         fs.mkdirSync(repoPath, { recursive: true });
         fs.mkdirSync(tabsRepo, { recursive: true });
         createSystemDirectories();   
-        console.log(`Creating directories: repoPath=${repoPath}, tabsRepo=${tabsRepo}`);     
         untildify.mockReturnValue(baseRepoPath);
         const returnedPath = untildify();
-        console.log(`untildify returned: ${returnedPath}`);
     });
 
     afterEach(() => {
@@ -157,7 +155,8 @@ describe("addTab", () => {
         expect(tabData.repo_id).toEqual(repo_id);
         // Assert tabs
         expect(tabData.tabs[0].file_id).toBe(tab1_fileId);
-        expect(typeof tabData.tabs[0].file_id).toBe('number');
+        expect(tabData.tabs[0].path).toBe(newFilePath1);
         expect(tabData.tabs[1].file_id).toBeNull();
+        expect(tabData.tabs[1].path).toBe(newFilePath2);
     });
 })

--- a/tests/test_events/handler/addTab.test.js
+++ b/tests/test_events/handler/addTab.test.js
@@ -76,7 +76,7 @@ describe("addTab", () => {
         configUtil.addRepo();
         addUser(baseRepoPath, false);
         const handler = new tabEventHandler(repoPath);
-        handler.handleTabChangeEvent();
+        handler.handleTabChangeEvent(false);
         // Verify no tab file should be generated
         assertNoTabsRecorded(tabsRepo)       
     })
@@ -90,8 +90,8 @@ describe("addTab", () => {
         assertNoTabsRecorded(tabsRepo)      
     })
 
-    // Skip case where file is changed
-    test("Should skip if file is changed", () => {
+    // Should skip if not opened/closed event
+    test("Should skip if not opened/closed event", () => {
         // Repo is connected & user account is also valid
         configUtil.addRepo();
         addUser(baseRepoPath, true);
@@ -103,10 +103,9 @@ describe("addTab", () => {
     })
 
     // Skip if invalid repo id
-    test("Should skip is repoId doesn't exist", () => {
-        const invalid_repo_path = "/home/documents"
+    test("Should skip if repoId doesn't exist", () => {
+        const invalid_repo_path = (repoPath).slice(0,5);
         const configUtil_2 = new Config(invalid_repo_path, configPath);
-        configUtil.addRepo();
         addUser(baseRepoPath, true);
         const handler = new tabEventHandler(invalid_repo_path);
         handler.handleTabChangeEvent(true);

--- a/tests/test_events/handler/addTab.test.js
+++ b/tests/test_events/handler/addTab.test.js
@@ -116,4 +116,41 @@ describe("addTab", () => {
         // Verify no tab file should be generated
         assertNoTabsRecorded(tabsRepo)    
     })
+
+    test("Tabs data in positive case", async () => {
+
+        jest.mock('vscode', () => {
+            return {
+              window: {
+                tabGroups: {
+                    all: jest.fn(),
+              },
+            },
+            };
+          });
+          
+        const vscode = require('vscode');
+        const mockTabGroups = [
+            { 
+                tabs: [
+                    { file_id: 1, path: 'home/documents/user/file1.txt' },
+                    { file_id: 2, path: 'home/documents/user/file2.txt' },
+                ],
+                activeTab: { id: 1 } 
+            }
+        ];
+        const spy = jest.spyOn(vscode.window.tabGroups, 'all').mockReturnValue(mockTabGroups);    
+        const result = vscode.window.tabGroups.all();
+
+        expect(result).toEqual(mockTabGroups);
+        expect(spy).toHaveBeenCalled();
+        expect(result[0].tabs).toHaveLength(2);
+        for (const tab of result[0].tabs) {
+            expect(tab['file_id']).toBeDefined();
+            expect(tab['path']).toBeDefined();
+            expect(typeof tab['file_id']).toBe('number');
+            expect(typeof tab['path']).toBe('string');
+        }
+    });
+    
 })

--- a/tests/test_events/handler/addTab.test.js
+++ b/tests/test_events/handler/addTab.test.js
@@ -1,0 +1,63 @@
+import fs from "fs";
+import path from "path";
+import untildify from "untildify";
+import {DATETIME_FORMAT, DEFAULT_BRANCH} from "../../../src/constants";
+import {randomBaseRepoPath, randomRepoPath} from "../../helpers/helpers";
+import dateFormat from "dateformat";
+import {readYML} from "../../../src/utils/common";
+import {VSCODE} from "../../../src/constants";
+import {pathUtils} from "../../../src/utils/path_utils";
+import {tabEventHandler} from "../../../src/events/tab_event_handler";
+import { createSystemDirectories } from "../../../src/utils/setup_utils";
+
+describe("addTab", () => {
+
+	const repoPath = randomRepoPath();
+    const baseRepoPath = randomBaseRepoPath();
+    untildify.mockReturnValue(baseRepoPath);
+
+    const pathUtilsObj = new pathUtils(repoPath, DEFAULT_BRANCH);
+    const tabsRepo = pathUtilsObj.getTabsRepo();
+    const newFilePath = path.join(repoPath, "new.js");
+
+    beforeEach(() => {
+        // Create directories
+        fs.mkdirSync(repoPath, { recursive: true });
+        fs.mkdirSync(tabsRepo, { recursive: true });
+        createSystemDirectories();   
+        console.log(`Creating directories: repoPath=${repoPath}, tabsRepo=${tabsRepo}`);     
+        jest.clearAllMocks();
+        untildify.mockReturnValue(baseRepoPath);
+        const returnedPath = untildify();
+        console.log(`untildify returned: ${returnedPath}`);
+    });
+
+    afterEach(() => {
+        fs.rmSync(repoPath, { recursive: true, force: true });
+        fs.rmSync(baseRepoPath, { recursive: true, force: true });
+    });
+
+    test('untildify should return the correct mocked path', () => {
+        untildify.mockReturnValue(baseRepoPath);
+        expect(untildify()).toBe(baseRepoPath);
+    });
+    
+    // Skips cases where repo is not connected OR file is changed
+    test("should be skipped",() => {
+        // Case: repo is not connected
+        // const repo_path = null;
+        const handler = new tabEventHandler(repoPath);
+        handler.handleTabChangeEvent();
+        // Verify no diff file should be generated
+        try {
+            console.log(`Tabs Repo`)
+            let tabFiles = fs.readdirSync(tabsRepo);
+            console.log("Tab files:", tabFiles);
+            expect(tabFiles).toHaveLength(0);
+        } catch (err) {
+            console.error("Error reading tabsRepo directory:", err);
+            throw err; // Re-throw the error to let the test fail
+        }
+        });
+
+})

--- a/tests/test_events/handler/handleChanges.test.js
+++ b/tests/test_events/handler/handleChanges.test.js
@@ -25,7 +25,7 @@ import { createSystemDirectories } from "../../../src/utils/setup_utils";
 describe("handleChangeEvent",  () => {
     /*
      {
-        source: 'vs-code',
+        source: 'vscode',
         created_at: '2021-08-26 18:59:51.954',
         diff: "",
         repo_path: 'tests/tests_data/test_repo_sNIVUqukDv',


### PR DESCRIPTION
## Changes
- Added a listener for tab changes.
- The pre-requisites for listening to tab changes are:
   1. Must be a valid user.
   2. Repo must be connected.
- Tab changes are recorded in two cases: 
   1.  When the IDE is opened.
   2.  When a user opens/closes tabs.
- Created a new directory `.codesync/.tabs`
- Structuring data in the format:
```
repo_id: 1234 
created_at: <timestamp>
source: vscode
file_name: 123232134343.yml
tabs: 
- file_id: <file_id> path: <path>     
- file_id: <file_id_1> path: <path_1>
```
- Dumping tabs data in YML file as `<timestamp>.yml`
- Added corresponding assertions for our case & ensured all tests are passing:

![image](https://github.com/codesyncapp/codesync-vs/assets/15974895/2907f906-8b3b-4a50-9fb3-8c72f7a92600)

