### PR TITLE
Capturing tabs after repo is connected 

### DIFF
--- a/src/events/tab_event_handler.ts
+++ b/src/events/tab_event_handler.ts
@@ -11,6 +11,7 @@ import { pathUtils } from "../utils/path_utils";
 import { generateSettings } from "../settings";
 import { RepoState } from "../utils/repo_state_utils";
 import { UserState } from "../utils/user_utils";
+import { CODESYNC_STATES, CodeSyncState } from "../utils/state_utils";
 
 export class tabEventHandler {
 	repoPath = "";
@@ -35,7 +36,7 @@ export class tabEventHandler {
 	}
 
 	handleTabChangeEvent = (createdAt: string, isTabEvent: boolean = true) => {
-		if (!isTabEvent || !this.shouldProceed) return;
+		if (!isTabEvent || !this.shouldProceed) return CodeSyncState.set(CODESYNC_STATES.ACTIVE_TAB_PATH, false);
 		// For the current open repoPath, get the repo_id and from config File
 		const configUtils = new ConfigUtils();
 		const repoId = configUtils.getRepoIdByPath(this.repoPath);

--- a/src/init/utils.ts
+++ b/src/init/utils.ts
@@ -19,7 +19,7 @@ import { s3UploaderUtils } from './s3_uploader';
 import { trackRepoHandler } from '../handlers/commands_handler';
 import gitCommitInfo from 'git-commit-info';
 import { RepoPlanLimitsState, RepoState } from '../utils/repo_state_utils';
-import { tabEventHandler } from '../events/tab_event_handler';
+import { captureTabs } from '../utils/tab_utils';
 
 export class initUtils {
 	repoPath: string;
@@ -253,13 +253,7 @@ export class initUtils {
 		await this.uploadRepoToS3(branch, json.response, syncingBranchKey);
 
 		// Capture tabs for newly connected repo
-		if (!repoId) {
-		const handler = new tabEventHandler(this.repoPath);
-		// Record timestamp
-		const createdAt = formatDatetime(new Date().getTime());
-		// Adding setTimeout here since 'isActive' key in tabs was not being properly assigned
-		setTimeout(() => handler.handleTabChangeEvent(createdAt), 1);
-		}
+		if (!repoId) captureTabs(this.repoPath);
 		return true;
 	}
 }

--- a/src/init/utils.ts
+++ b/src/init/utils.ts
@@ -13,12 +13,13 @@ import { checkServerDown } from '../utils/api_utils';
 import { IFileToUpload } from '../interface';
 import { uploadRepoToServer } from '../utils/upload_utils';
 import { CONNECTION_ERROR_MESSAGE, VSCODE, NOTIFICATION, BRANCH_SYNC_TIMEOUT, contextVariables } from '../constants';
-import { getGlobIgnorePatterns, readYML, getSyncIgnoreItems, shouldIgnorePath, getDefaultIgnorePatterns } from '../utils/common';
+import { getGlobIgnorePatterns, readYML, getSyncIgnoreItems, shouldIgnorePath, getDefaultIgnorePatterns, formatDatetime } from '../utils/common';
 import { CodeSyncState, CODESYNC_STATES } from '../utils/state_utils';
 import { s3UploaderUtils } from './s3_uploader';
 import { trackRepoHandler } from '../handlers/commands_handler';
 import gitCommitInfo from 'git-commit-info';
 import { RepoPlanLimitsState, RepoState } from '../utils/repo_state_utils';
+import { tabEventHandler } from '../events/tab_event_handler';
 
 export class initUtils {
 	repoPath: string;
@@ -251,6 +252,14 @@ export class initUtils {
 		// Upload to s3
 		await this.uploadRepoToS3(branch, json.response, syncingBranchKey);
 
+		// Capture tabs for newly connected repo
+		if (!repoId) {
+		const handler = new tabEventHandler(this.repoPath);
+		// Record timestamp
+		const createdAt = formatDatetime(new Date().getTime());
+		// Adding setTimeout here since 'isActive' key in tabs was not being properly assigned
+		setTimeout(() => handler.handleTabChangeEvent(createdAt), 1);
+		}
 		return true;
 	}
 }

--- a/src/utils/tab_utils.ts
+++ b/src/utils/tab_utils.ts
@@ -1,5 +1,7 @@
 import fs from "fs";
 import { CodeSyncLogger } from '../logger';
+import { tabEventHandler } from "../events/tab_event_handler";
+import { formatDatetime } from "./common";
 
 export const removeTabFile = (filePath: string, funcName: string) => {
 	fs.unlink(filePath, err => {
@@ -7,5 +9,15 @@ export const removeTabFile = (filePath: string, funcName: string) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		CodeSyncLogger.error(`${funcName}: Error deleting file`, err);
-	});	
+	});
+
 };
+
+export const captureTabs = (repoPath: string, isTabEvent: boolean = true) => {
+	const handler = new tabEventHandler(repoPath);
+	// Record timestamp
+	const createdAt = formatDatetime(new Date().getTime());
+	// Adding setTimeout here since 'isActive' key in tabs was not being properly assigned
+	setTimeout(() => handler.handleTabChangeEvent(createdAt, isTabEvent), 1);
+}
+

--- a/tests/test_init/handler.test.js
+++ b/tests/test_init/handler.test.js
@@ -267,6 +267,32 @@ describe("initHandler: Syncing Branch", () => {
     });
 
     test("Should sync branch", async () => {
+        const mockTabs = [
+            {
+                tabs: [
+                    {
+                        input: {
+                                uri: {
+                                    path: 'newFilePath1',
+                            }
+                        },
+                        isActive: true,
+                    },
+                    {
+                        input: {
+                                uri: {
+                                    path: 'newFilePath2',
+                            }
+                        },
+                        isActive: false,
+                    },
+                ]
+            }
+        ]
+    Object.defineProperty(vscode.window.tabGroups, 'all', {
+        get: jest.fn(() => mockTabs),
+      });
+
         isOnline.mockReturnValue(true);
         fs.writeFileSync(filePath, DUMMY_FILE_CONTENT);
         fetchMock

--- a/tests/test_init/utils.test.js
+++ b/tests/test_init/utils.test.js
@@ -254,6 +254,28 @@ describe("uploadRepo",  () => {
         "file_1.js": null,
     };
     expectedConfig[NESTED_PATH] = null;
+    const mockTabs = [
+        {
+            tabs: [
+                {
+                    input: {
+                            uri: {
+                                path: 'newFilePath1',
+                        }
+                    },
+                    isActive: true,
+                },
+                {
+                    input: {
+                            uri: {
+                                path: 'newFilePath2',
+                        }
+                    },
+                    isActive: false,
+                },
+            ]
+        }
+    ]
 
     beforeEach(() => {
         fetch.resetMocks();
@@ -305,6 +327,9 @@ describe("uploadRepo",  () => {
 
     test("repo In Config",  async () => {
         isOnline.mockReturnValue(true);
+        Object.defineProperty(vscode.window.tabGroups, 'all', {
+            get: jest.fn(() => mockTabs),
+        });
 
         // Generate ItemPaths
         const initUtilsObj = new initUtils(repoPath);
@@ -351,6 +376,9 @@ describe("uploadRepo",  () => {
     });
 
     test("repo Not In Config",  async () => {
+        Object.defineProperty(vscode.window.tabGroups, 'all', {
+            get: jest.fn(() => mockTabs),
+          });    
         const configUtil = new Config(repoPath, configPath);
         configUtil.removeRepo();
         const initUtilsObj = new initUtils(repoPath);


### PR DESCRIPTION
## Changes
- Setting `isActiveTab` to default value if  `!isTabEvent || !this.shouldProceed`
- Capturing initial state of tabs for when repo is connected
- Added further assertions for WebSocket Events related to tabs, specifically testing the status codes received from server. Namely:
-- Status 400 recieved.
-- Status 403 recieved.
-- Status 402 recieved.
- Fixed some failing tests.